### PR TITLE
[#78][Refactor] Separate header files from commandParser and executor

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -128,13 +128,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="commandParser.cpp" />
-    <ClCompile Include="commendParser_test.cpp">
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
+    <ClCompile Include="commendParser_test.cpp" />
     <ClCompile Include="executor.cpp" />
-    <ClCompile Include="executor_test.cpp">
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
+    <ClCompile Include="executor_test.cpp" />
     <ClCompile Include="main.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
@@ -144,16 +140,19 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
+    <ClCompile Include="ssdApp.cpp" />
     <ClCompile Include="testScript.cpp" />
-    <ClCompile Include="testScript_test.cpp">
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
+    <ClCompile Include="testScript_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="commandParser.h" />
+    <ClInclude Include="executor.h" />
+    <ClInclude Include="global_config.h" />
     <ClInclude Include="interface.h" />
+    <ClInclude Include="ssdApp.h" />
     <ClInclude Include="testScript.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="testScript.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="ssdApp.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -60,6 +63,18 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="interface.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="commandParser.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="executor.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ssdApp.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="global_config.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TestShell/commandParser.cpp
+++ b/TestShell/commandParser.cpp
@@ -1,30 +1,16 @@
-#include <iostream>
-#include <string>
-#include "interface.h"
+#include "commandParser.h"
 
-using namespace std;
+bool CommandParser::ParseCommand(string cmd)
+{
+    if (IsVaildCommand(cmd) == false) return false;
 
-class ICommandParserBridge {
-public:
-    virtual bool ParseCommand(string cmd) = 0;
-};
+    executor = ExecutorFactory().createExecutor(cmd);
+    if (executor == nullptr) return false;
 
-class CommandParser : public ICommandParserBridge {
-public:
-    bool ParseCommand(string cmd) override {
-        if (IsVaildCommand(cmd) == false)
-            return false;
+    return true;
+}
 
-		executor = ExecutorFactory().createExecutor(cmd);
-        if (executor == nullptr) {
-            return false;
-		}
-        return true;
-    }
-private:
-    bool IsVaildCommand(string cmd) {
-        return true;
-    }
-
-    IExecutor* executor;
-};
+bool CommandParser::IsVaildCommand(string cmd)
+{
+    return true;
+}

--- a/TestShell/commandParser.h
+++ b/TestShell/commandParser.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <string>
+#include "interface.h"
+
+using namespace std;
+
+class ICommandParserBridge
+{
+public:
+    virtual bool ParseCommand(string cmd) = 0;
+};
+
+class CommandParser : public ICommandParserBridge {
+public:
+    bool ParseCommand(string cmd) override;
+
+private:
+    bool IsVaildCommand(string cmd);
+
+    IExecutor* executor;
+};

--- a/TestShell/commendParser_test.cpp
+++ b/TestShell/commendParser_test.cpp
@@ -1,9 +1,7 @@
 #ifdef _DEBUG
-#include <string>
 #include "gmock/gmock.h"
-#include "commandParser.cpp"
+#include "commandParser.h"
 
-using namespace std;
 using namespace testing;
 
 class CommandParserFixture : public Test {

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -1,98 +1,66 @@
 #include <iostream>
-#include <exception>
-#include "global_config.h"
-#include "interface.h"
+#include "executor.h"
 
-using std::string;
-using std::cout;
-using std::endl;
+using namespace std;
 
-class SsdApp : public ISsdApp {
-public:
-	DATA Read(LBA lba) override {
-		// TODO: need to execute existing exe file of ssd
-	}
-
-	bool Write(LBA lba, DATA data) override {
-		// TODO: need to execute existing exe file of ssd
-	}
-
-	static SsdApp* getInstance() {
-		static SsdApp instance;
-		return &instance;
-	}
-private:
-	SsdApp() {}
-};
-
-class Writer : public IExecutor {
-public:
-	bool execute(const string& command, LBA lba, DATA data, ISsdApp * app) override {
-		if (command == "write") {
-			app->Write(lba, data);
-			return true;
-		}
-		else if (command == "fullwrite") {
-			for (LBA lba = 0; lba < SSD_MAX_SIZE; ++lba) app->Write(lba, data);
-			return true;
-		}
-		return false;
-	}
-};
-
-class Reader : public IExecutor {
-public:
-	bool execute(const string& command, LBA lba, DATA data, ISsdApp * app) override {
-		if (command == "read") {
-			app->Read(lba);
-			return true;
-		}
-		else if (command == "fullread") {
-			for (DATA lba = 0; lba < SSD_MAX_SIZE; ++lba) app->Read(lba);
-			return true;
-		}
-		return false;
-	}
-};
-
-class Helper : public IExecutor {
-public:
-	bool execute(const string& command, LBA lba, DATA data, ISsdApp *app) override {
-		cout << "팀명: CCC(Clean Code Collective) \n";
-		cout << "팀장 : 김범진 / 팀원 : 김경민, 김윤진, 김율곤, 정지윤\n\n";
-		cout << "Command 설명:\n";
-		cout << "write: 필요 파라미터 lba(0~99 중), data(32bit 16진수 값) - ssd의 lba cell에 data를 저장한다.\n";
-		cout << "fullwrite: 필요 파라미터 data(32bit 16진수 값) - ssd의 모든 cell에 data를 저장한다.\n";
-		cout << "read: 필요 파라미터 lba(0~99 중) - ssd의 lba cell의 값을 읽어온다.\n";
-		cout << "fullread: 필요 파라미터 NONE - ssd의 모든 cell의 값을 읽어온다\n";
-		cout << "help: 필요 파라미터 NONE - ssd에 필요한 command 등 모든 정보에 대한 도움말을 요청한다\n";
-		cout << "exit: 필요 파라미터 NONE - 하려던 거 끝내고 바로 종료한다\n" << endl;
-
-		return true;
-	}
-};
-
-class Exiter : public IExecutor {
-public:
-	bool execute(const string& command, LBA lba, DATA data, ISsdApp *app) override {
-		cout << "Exit!!" << endl;
-		return true;
-	}
-};
-
-IExecutor* ExecutorFactory::createExecutor(const string command) {
-	if (command == "write" || command == "fullwrite") {
-		return new Writer();
-	}
-	else if (command == "read" || command == "fullread") {
-		return new Reader();
-	}
-	else if (command == "help") {
-		return new Helper();
-	}
-	else if (command == "exit") {
-		return new Exiter();
-	}
+IExecutor* ExecutorFactory::createExecutor(const string command)
+{
+	if (command == "write" || command == "fullwrite") return new Writer();
+	if (command == "read" || command == "fullread") return new Reader();
+	if (command == "help") return new Helper();
+	if (command == "exit") return new Exiter();
 
 	return nullptr;
 }
+
+bool Writer::execute(const string& command, LBA lba, DATA data, ISsdApp * app)
+{
+	if (command == "write")
+	{
+		app->Write(lba, data);
+		return true;
+	}
+	else if (command == "fullwrite")
+	{
+		for (LBA lba = 0; lba < SSD_MAX_SIZE; ++lba) app->Write(lba, data);
+		return true;
+	}
+	return false;
+}
+
+bool Reader::execute(const string& command, LBA lba, DATA data, ISsdApp * app)
+{
+	if (command == "read")
+	{
+		app->Read(lba);
+		return true;
+	}
+	else if (command == "fullread")
+	{
+		for (DATA lba = 0; lba < SSD_MAX_SIZE; ++lba) app->Read(lba);
+		return true;
+	}
+	return false;
+}
+
+bool Helper::execute(const string& command, LBA lba, DATA data, ISsdApp *app)
+{
+	cout << "팀명: CCC(Clean Code Collective) \n";
+	cout << "팀장 : 김범진 / 팀원 : 김경민, 김윤진, 김율곤, 정지윤\n\n";
+	cout << "Command 설명:\n";
+	cout << "write: 필요 파라미터 lba(0~99 중), data(32bit 16진수 값) - ssd의 lba cell에 data를 저장한다.\n";
+	cout << "fullwrite: 필요 파라미터 data(32bit 16진수 값) - ssd의 모든 cell에 data를 저장한다.\n";
+	cout << "read: 필요 파라미터 lba(0~99 중) - ssd의 lba cell의 값을 읽어온다.\n";
+	cout << "fullread: 필요 파라미터 NONE - ssd의 모든 cell의 값을 읽어온다\n";
+	cout << "help: 필요 파라미터 NONE - ssd에 필요한 command 등 모든 정보에 대한 도움말을 요청한다\n";
+	cout << "exit: 필요 파라미터 NONE - 하려던 거 끝내고 바로 종료한다\n" << endl;
+
+	return true;
+}
+
+bool Exiter::execute(const string& command, LBA lba, DATA data, ISsdApp *app)
+{
+	cout << "Exit!!" << endl;
+	return true;
+}
+

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "global_config.h"
+#include "interface.h"
+
+class Writer : public IExecutor
+{
+public:
+	bool execute(const string& command, LBA lba, DATA data, ISsdApp* app) override;
+};
+
+class Reader : public IExecutor
+{
+public:
+	bool execute(const string& command, LBA lba, DATA data, ISsdApp* app) override;
+};
+
+class Helper : public IExecutor
+{
+public:
+	bool execute(const string& command, LBA lba, DATA data, ISsdApp* app) override;
+};
+
+class Exiter : public IExecutor {
+public:
+	bool execute(const string& command, LBA lba, DATA data, ISsdApp* app) override;
+};

--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <string>
-#include "commandParser.cpp"
+#include "commandParser.h"
 
 using namespace std;
 

--- a/TestShell/ssdApp.cpp
+++ b/TestShell/ssdApp.cpp
@@ -1,0 +1,19 @@
+#include "ssdApp.h"
+
+DATA SsdApp::Read(LBA lba)
+{
+	// TODO: need to execute existing exe file of ssd
+	return 0;
+}
+
+bool SsdApp::Write(LBA lba, DATA data)
+{
+	// TODO: need to execute existing exe file of ssd
+	return true;
+}
+
+SsdApp* SsdApp::getInstance()
+{
+	static SsdApp instance;
+	return &instance;
+}

--- a/TestShell/ssdApp.h
+++ b/TestShell/ssdApp.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "global_config.h"
+#include "interface.h"
+
+class SsdApp : public ISsdApp
+{
+public:
+	DATA Read(LBA lba) override;
+
+	bool Write(LBA lba, DATA data);
+
+	static SsdApp* getInstance();
+
+private:
+	SsdApp() {}
+};


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #78 

## 제목
- [#78][Refactor] Separate header files from commandParser and executor

## 프로젝트
- [ ] SSD
- [ ] TestShell
- [x] TestScript

## 변경 사항
- cpp 파일(commandParser and executor)에서 header  분리
