### PR TITLE
[#76#80][TDD_GREEN] tdd red output data format fix

### DIFF
--- a/SSDProject/ssd.cpp
+++ b/SSDProject/ssd.cpp
@@ -1,5 +1,7 @@
 #include "ssd.h"
 #include <fstream>
+#include <sstream>
+#include <iomanip>
 #include <string>
 
 bool SSD::read(LBA lba)
@@ -16,8 +18,14 @@ bool SSD::read(LBA lba)
   {
     return false;
   }
-  
-  _updateOutputFile(std::to_string(readData));
+
+  std::stringstream ss;
+  ss << "0x"
+    << std::setw(8) << std::setfill('0')  // 8자리 0패딩
+    << std::hex << std::uppercase         // 대문자 16진수
+    << readData;
+  std::string hexStr = ss.str();
+  _updateOutputFile(hexStr);
 
   return true;
 }

--- a/SSDProject/ssd_test.cpp
+++ b/SSDProject/ssd_test.cpp
@@ -26,7 +26,7 @@ public:
 
   const LBA VALID_LBA = 5;
   const LBA INVALID_LBA = 101;
-  const std::string WRITE_DATA = "0xdeadcafe";
+  const std::string WRITE_DATA = "0xDEADCAFE";
   const std::string INVALID_DATA = "0x00000000";
   const std::string outputFile = "ssd_output.txt";
 


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #76 

## 프로젝트
- [x] SSD
- [ ] TestShell
- [ ] TestScript

## 변경 사항
- SSD_Read 시 output 파일에 기록되는 data 양식을 교안에 맞게 UT FIX
- output file에 int 값 그대로 적도록 구현한 코드를 교안에 맞게 "0xDEADCAFE" 와 같은 Hexa 포맷으로 적도록 구현 수정
