### PR TITLE
[#118][BugFix] fix return c_str to string and then c_str as system func param

### DIFF
--- a/TestShell/ssdApp.cpp
+++ b/TestShell/ssdApp.cpp
@@ -9,12 +9,14 @@ using std::cout;
 using std::endl;
 
 DATA SsdApp::Read(LBA lba) {
-	system(makeExecuteCmd(SEND_READ_CMD, lba));
+	string sendReadString = makeExecuteCmd(SEND_READ_CMD, lba);
+	system(sendReadString.c_str());
 	return 0;
 }
 
 bool SsdApp::Write(LBA lba, DATA data) {
-	system(makeExecuteCmd(SEND_WRITE_CMD, lba, data));
+	string sendWriteString = makeExecuteCmd(SEND_WRITE_CMD, lba, data);
+	system(sendWriteString.c_str());
 	return true;
 }
 
@@ -24,7 +26,7 @@ SsdApp* SsdApp::getInstance()
 	return &instance;
 }
 
-const char* SsdApp::makeExecuteCmd(string cmd, LBA lba, DATA data) {
+const string SsdApp::makeExecuteCmd(string cmd, LBA lba, DATA data) {
 	std::ostringstream oss;
 	oss << EXE_FILE_NAME << " " << cmd << " " << lba;
 	if (cmd == SEND_WRITE_CMD) {
@@ -32,7 +34,7 @@ const char* SsdApp::makeExecuteCmd(string cmd, LBA lba, DATA data) {
 	}
 	string commandStr = oss.str();
 	cout << commandStr << endl;
-	return commandStr.c_str();
+	return commandStr;
 }
 
 string SsdApp::_DataToHexString(const DATA data)

--- a/TestShell/ssdApp.h
+++ b/TestShell/ssdApp.h
@@ -13,7 +13,7 @@ public:
 
 private:
 	SsdApp() {}
-	const char* makeExecuteCmd(string cmd, LBA lba = 0, DATA data = 0);
+	const string makeExecuteCmd(string cmd, LBA lba = 0, DATA data = 0);
 	string _DataToHexString(const DATA data);
 
 	const int DATA_NUM_DIGIT = 8;


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: `#123`
#118

## 제목
- [PREFIX] PR 제목을 간결하게 작성해주세요.

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- 변경된 내용을 요약해주세요.
makeExecuteCmd에서 return할 때 const char *로 하지 않고 string으로 한 후 system함수 호출할 때 c_str으로 변환하도록 변경
