### PR TITLE
[#148][refactor] remove command parameter from execute

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -128,7 +128,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="commandParser.cpp" />
-    <ClCompile Include="commendParser_test.cpp" />
+    <ClCompile Include="commandParser_test.cpp" />
     <ClCompile Include="executor.cpp" />
     <ClCompile Include="executor_test.cpp" />
     <ClCompile Include="main.cpp">

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -27,7 +27,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="commendParser_test.cpp">
+    <ClCompile Include="commandParser_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
     <ClCompile Include="commandParser.cpp">

--- a/TestShell/commandParser.cpp
+++ b/TestShell/commandParser.cpp
@@ -18,7 +18,7 @@ bool CommandParser::ParseCommand(const string& fullCmd) {
 
 bool CommandParser::ExecuteSsdUsingParsedCommand(ISsdApp* app) {
     if (app == nullptr) return false;
-    return executor->execute(app, command, lba, data);
+    return executor->execute(app, lba, data);
 }
 
 bool CommandParser::IsVaildCommand(const string& cmd, size_t tokenSize) {

--- a/TestShell/commandParser_test.cpp
+++ b/TestShell/commandParser_test.cpp
@@ -26,16 +26,16 @@ TEST_F(CommandParserFixture, HelpCommand) {
 
 TEST_F(CommandParserFixture, FullwriteCommand) {
     EXPECT_CALL(mock_app, Write)
-        .Times(100)
-        .WillRepeatedly(Return(true));
+        .Times(1)
+        .WillOnce(Return(true));
 
     CheckParseCommand(FULL_WRITE_CMD, 0, TEST_DATA);
 }
 
 TEST_F(CommandParserFixture, fullreadCommand) {
     EXPECT_CALL(mock_app, Read)
-        .Times(100)
-        .WillRepeatedly(Return(true));
+        .Times(1)
+        .WillOnce(Return(true));
 
     CheckParseCommand(FULL_READ_CMD);
 }

--- a/TestShell/commandParser_test.cpp
+++ b/TestShell/commandParser_test.cpp
@@ -26,7 +26,7 @@ TEST_F(CommandParserFixture, HelpCommand) {
 
 TEST_F(CommandParserFixture, FullwriteCommand) {
     EXPECT_CALL(mock_app, Write)
-        .Times(1)
+        .Times(SSD_MAX_SIZE)
         .WillOnce(Return(true));
 
     CheckParseCommand(FULL_WRITE_CMD, 0, TEST_DATA);
@@ -34,7 +34,7 @@ TEST_F(CommandParserFixture, FullwriteCommand) {
 
 TEST_F(CommandParserFixture, fullreadCommand) {
     EXPECT_CALL(mock_app, Read)
-        .Times(1)
+        .Times(SSD_MAX_SIZE)
         .WillOnce(Return(true));
 
     CheckParseCommand(FULL_READ_CMD);

--- a/TestShell/compositExecutor.cpp
+++ b/TestShell/compositExecutor.cpp
@@ -1,4 +1,5 @@
 #include "CompositExecutor.h"
+#include "utils.h"
 #include <iostream>
 #ifdef _DEBUG
 #include <stdexcept>
@@ -8,7 +9,14 @@
 
 bool CompositExecutor::ReadCompare(ISsdApp* app, LBA lba, DATA expectedData)
 {
-	bool result = reader->execute(app, SCRIPT_READ_CMD, lba, expectedData);
+	bool result = reader->execute(app, lba, expectedData);
+
+	DATA read_result = stringToUnsignedInt(reader->GetResultFromFile());
+	if (read_result == expectedData) result = true;
+#if (FIX_ME_LATER == 1)
+		cout << "[Read] Expected LBA " << lba << " : " << expectedData << "\n";
+		cout << "[Read] Real LBA " << lba << " : " << result << "\n";
+#endif
 
 #ifndef _DEBUG
 	if (result == false) cout << "FAIL\n";
@@ -20,7 +28,7 @@ bool CompositExecutor::ReadCompare(ISsdApp* app, LBA lba, DATA expectedData)
 }
 
 
-bool FullWriteAndReadCompare::execute(ISsdApp* app, const string& command, LBA lba, DATA data)
+bool FullWriteAndReadCompare::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	for (int loop = 0; loop < LOOP_COUNT; loop++)
 	{
@@ -30,7 +38,7 @@ bool FullWriteAndReadCompare::execute(ISsdApp* app, const string& command, LBA l
 
 		for (int lba = startLba; lba < endLba; lba++)
 		{
-			writer->execute(app, SCRIPT_WRITE_CMD, lba, inputData);
+			writer->execute(app, lba, inputData);
 		}
 
 		for (int lba = startLba; lba < endLba; lba++)
@@ -43,7 +51,7 @@ bool FullWriteAndReadCompare::execute(ISsdApp* app, const string& command, LBA l
 	return true;
 }
 
-bool PartialLBAWrite::execute(ISsdApp* app, const string& command, LBA lba, DATA data)
+bool PartialLBAWrite::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	LBA writeLba[5] = { 4, 0, 3, 1, 2 };
 	LBA readStartLba = 0;
@@ -55,7 +63,7 @@ bool PartialLBAWrite::execute(ISsdApp* app, const string& command, LBA lba, DATA
 
 		for (auto lba : writeLba)
 		{
-			writer->execute(app, SCRIPT_WRITE_CMD, lba, inputData);
+			writer->execute(app, lba, inputData);
 		}
 
 		for (int lba = readStartLba; lba < readEndLba; lba++)
@@ -68,7 +76,7 @@ bool PartialLBAWrite::execute(ISsdApp* app, const string& command, LBA lba, DATA
 	return true;
 }
 
-bool WriteReadAging::execute(ISsdApp* app, const string& command, LBA lba, DATA data)
+bool WriteReadAging::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	LBA ioLba[2] = { 0, 99 };
 
@@ -85,7 +93,7 @@ bool WriteReadAging::execute(ISsdApp* app, const string& command, LBA lba, DATA 
 
 		for (int index = 0; index < NUM_LBA_PER_LOOP; index++)
 		{
-			writer->execute(app, SCRIPT_WRITE_CMD, ioLba[index], inputData[index]);
+			writer->execute(app, ioLba[index], inputData[index]);
 		}
 
 		for (int index = 0; index < NUM_LBA_PER_LOOP; index++)

--- a/TestShell/compositExecutor.h
+++ b/TestShell/compositExecutor.h
@@ -25,7 +25,7 @@ public:
 	static const int LOOP_COUNT = 20;
 	static const int NUM_LBA_PER_LOOP = 5;
 
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba, DATA data);
 };
 
 class PartialLBAWrite : public CompositExecutor {
@@ -36,7 +36,7 @@ public:
 	static const int LOOP_COUNT = 30;
 	static const int NUM_LBA_PER_LOOP = 5;
 
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba, DATA data);
 };
 
 class WriteReadAging : public CompositExecutor {
@@ -47,5 +47,5 @@ public:
 	static const int LOOP_COUNT = 200;
 	static const int NUM_LBA_PER_LOOP = 2;
 
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba, DATA data);
 };

--- a/TestShell/compositExecutor_test.cpp
+++ b/TestShell/compositExecutor_test.cpp
@@ -13,12 +13,12 @@ public:
 class MockWriter : public Writer
 {
 public:
-	MOCK_METHOD(bool, execute, (ISsdApp*, const string&, LBA, DATA), (override));
+	MOCK_METHOD(bool, execute, (ISsdApp*, LBA, DATA), (override));
 };
 
 class MockReader : public Reader {
 public:
-	MOCK_METHOD(bool, execute, (ISsdApp*, const string&, LBA, DATA), (override));
+	MOCK_METHOD(bool, execute, (ISsdApp*, LBA, DATA), (override));
 };
 
 class CompositExecutorFixture : public Test {
@@ -29,9 +29,6 @@ public:
 
 	const string BLANK_TEST_SCRIPT_NAME = "";
 	const string INVALID_TEST_SCRIPT_NAME = "123";
-	const string FIRST_TEST_SCRIPT_NAME = "1_";
-	const string SECOND_TEST_SCRIPT_NAME = "2_";
-	const string THIRD_TEST_SCRIPT_NAME = "3_";
 
 	const int FIRST_TEST_SCRIPT_MAX_IO_TIMES =
 		FullWriteAndReadCompare::LOOP_COUNT * FullWriteAndReadCompare::NUM_LBA_PER_LOOP;
@@ -66,7 +63,7 @@ TEST_F(CompositExecutorFixture, CompositExecutor1CheckMockReadWriteMaxTimes) {
 	EXPECT_CALL(mockReader, execute)
 		.Times(FIRST_TEST_SCRIPT_MAX_IO_TIMES);
 
-	mockFirstApp.execute(&mockSsdApp, FIRST_TEST_SCRIPT_NAME, 0, 0);
+	mockFirstApp.execute(&mockSsdApp, 0, 0);
 }
 
 TEST_F(CompositExecutorFixture, CompositExecutor2CheckMockReadWriteMaxTimes) {
@@ -76,7 +73,7 @@ TEST_F(CompositExecutorFixture, CompositExecutor2CheckMockReadWriteMaxTimes) {
 	EXPECT_CALL(mockReader, execute)
 		.Times(SECOND_TEST_SCRIPT_MAX_IO_TIMES);
 
-	mockSecondApp.execute(&mockSsdApp, SECOND_TEST_SCRIPT_NAME, 0, 0);
+	mockSecondApp.execute(&mockSsdApp, 0, 0);
 }
 
 TEST_F(CompositExecutorFixture, CompositExecutor3CheckMockReadWriteMaxTimes) {
@@ -86,7 +83,7 @@ TEST_F(CompositExecutorFixture, CompositExecutor3CheckMockReadWriteMaxTimes) {
 	EXPECT_CALL(mockReader, execute)
 		.Times(THIRD_TEST_SCRIPT_MAX_IO_TIMES);
 
-	mockThirdApp.execute(&mockSsdApp, THIRD_TEST_SCRIPT_NAME, 0, 0);
+	mockThirdApp.execute(&mockSsdApp, 0, 0);
 }
 
 #endif

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -10,8 +10,10 @@ using namespace std;
 
 IExecutor* ExecutorFactory::createExecutor(const string command)
 {
-	if (command == WRITE_CMD || command == FULL_WRITE_CMD) return new Writer();
-	if (command == READ_CMD || command == FULL_READ_CMD) return new Reader();
+	if (command == WRITE_CMD) return new Writer();
+	if (command == FULL_WRITE_CMD) return new FullWriter();
+	if (command == READ_CMD) return new Reader();
+	if (command == FULL_READ_CMD) return new FullReader();
 	if (command == HELP_CMD) return new Helper();
 	if (command == EXIT_CMD) return new Exiter();
 	if (command == FIRST_SCRIPT_SHORT_NAME || command == FIRST_SCRIPT_FULL_NAME)return new FullWriteAndReadCompare(new Writer(), new Reader());

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -5,23 +5,35 @@
 class Writer : public IExecutor
 {
 public:
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+};
+
+class FullWriter : public Writer
+{
+public:
+	bool execute(ISsdApp* app, LBA lba, DATA data) override;
 };
 
 class Reader : public IExecutor
 {
 public:
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba, DATA data = 0) override;
+
 	string GetResultFromFile(void);
-
+private:
 	const string OUTPUT_NAME = "ssd_output.txt";
+};
 
+class FullReader : public Reader
+{
+public:
+	bool execute(ISsdApp* app, LBA lba, DATA data) override;
 };
 
 class Helper : public IExecutor
 {
 public:
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 private:
 	const std::string HELP_DESCRIPTION =
 		"ÆÀ¸í: CCC(Clean Code Collective) \n"
@@ -37,5 +49,5 @@ private:
 
 class Exiter : public IExecutor {
 public:
-	bool execute(ISsdApp* app, const string& command, LBA lba, DATA data) override;
+	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 };

--- a/TestShell/executor_test.cpp
+++ b/TestShell/executor_test.cpp
@@ -17,7 +17,7 @@ public:
 	void checkExecute(string cmd = "", LBA lba = 0, DATA data = 0, DATA expect_data = 0) {
 		executor = ExecutorFactory().createExecutor(cmd);
 
-		bool ret = executor->execute(&mock_app, cmd, lba, data);
+		bool ret = executor->execute(&mock_app, lba, data);
 		EXPECT_TRUE(ret);
 	}
 
@@ -43,8 +43,9 @@ TEST_F(ExecutorTestFixture, writeCommandTest) {
 
 TEST_F(ExecutorTestFixture, fullWriteCommandTest) {
 	EXPECT_CALL(mock_app, Write)
-		.Times(100)
-		.WillRepeatedly(Return(true));
+		.Times(1)
+		.WillOnce(Return(true));
+	(Return(true));
 	
 	checkExecute(FULL_WRITE_CMD, 0, TEST_DATA);
 }
@@ -59,8 +60,8 @@ TEST_F(ExecutorTestFixture, readNonWriteTest) {
 
 TEST_F(ExecutorTestFixture, fullreadCommandTest) {
 	EXPECT_CALL(mock_app, Read)
-		.Times(100)
-		.WillRepeatedly(Return(NO_DATA));
+		.Times(1)
+		.WillOnce(Return(NO_DATA));
 
 	checkExecute(FULL_READ_CMD, 0, 0, NO_DATA);
 }

--- a/TestShell/executor_test.cpp
+++ b/TestShell/executor_test.cpp
@@ -43,7 +43,7 @@ TEST_F(ExecutorTestFixture, writeCommandTest) {
 
 TEST_F(ExecutorTestFixture, fullWriteCommandTest) {
 	EXPECT_CALL(mock_app, Write)
-		.Times(1)
+		.Times(SSD_MAX_SIZE)
 		.WillOnce(Return(true));
 	(Return(true));
 	
@@ -60,7 +60,7 @@ TEST_F(ExecutorTestFixture, readNonWriteTest) {
 
 TEST_F(ExecutorTestFixture, fullreadCommandTest) {
 	EXPECT_CALL(mock_app, Read)
-		.Times(1)
+		.Times(SSD_MAX_SIZE)
 		.WillOnce(Return(NO_DATA));
 
 	checkExecute(FULL_READ_CMD, 0, 0, NO_DATA);

--- a/TestShell/global_config.h
+++ b/TestShell/global_config.h
@@ -17,8 +17,6 @@ const string FULL_WRITE_CMD = "fullwrite";
 const string HELP_CMD = "help";
 const string EXIT_CMD = "exit";
 
-const string SCRIPT_READ_CMD = "scriptread";
-const string SCRIPT_WRITE_CMD = "scriptwrite";
 const string FIRST_SCRIPT_SHORT_NAME = "1_";
 const string FIRST_SCRIPT_FULL_NAME = "1_FullWriteAndReadCompare";
 const string SECOND_SCRIPT_SHORT_NAME = "2_";

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -15,7 +15,7 @@ interface ISsdApp {
 };
 
 interface IExecutor {
-	virtual bool execute(ISsdApp* pApp = nullptr, const string& command = "", u32 lba = 0, u32 data = 0) = 0;
+	virtual bool execute(ISsdApp* pApp = nullptr, u32 lba = 0, u32 data = 0) = 0;
 };
 
 class ICommandParserBridge

--- a/TestShell/shellInterface_test.cpp
+++ b/TestShell/shellInterface_test.cpp
@@ -41,7 +41,7 @@ public:
         shell->setSsdApp(&mock_app);
 
         istringstream iss(cmd);
-        ostringstream oss;
+        ostringstream oss = {};
 
         auto* oldInputBuf = cin.rdbuf();
         streambuf* oldOutputBuf = cout.rdbuf();

--- a/TestShell/utils.cpp
+++ b/TestShell/utils.cpp
@@ -15,7 +15,9 @@ const string makeExecuteCmd(string cmd, LBA lba, DATA data) {
 		oss << " " << DataToHexString(data);
 	}
 	string commandStr = oss.str();
+#ifdef _DEBUG
 	cout << commandStr << endl;
+#endif
 	return commandStr;
 }
 


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #148

## 제목
- [PREFIX] remove command parameter from execute

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- 이제 모든 execute 함수는 const string& command를 받지 않습니다.
- virtual bool execute(ISsdApp* pApp = nullptr, u32 lba = 0, u32 data = 0) = 0;
- UT 확인 완료
- Release build 동작 확인 완료
- 추가 수정: Factory에서 fullread / fullwrite에 따른 FullReader / FullWriter 따로 생성
- 위 추가 수정으로 인한 UT 수정
