### PR TITLE
[#124][feature] TestShell app supports erase, erase_range command

### DIFF
--- a/TestShell/commandParser.cpp
+++ b/TestShell/commandParser.cpp
@@ -25,6 +25,7 @@ bool CommandParser::IsVaildCommand(const string& cmd, size_t tokenSize) {
     if (cmd_set.find(cmd) != cmd_set.end()) {
         if (IsWriteCmdValid(cmd, tokenSize)) return true;
         else if (IsReadCmdValid(cmd, tokenSize)) return true;
+        else if (IsEraseCmdValid(cmd, tokenSize)) return true;
         else if (tokenSize == 1) return true;
         return false;
     }
@@ -33,6 +34,11 @@ bool CommandParser::IsVaildCommand(const string& cmd, size_t tokenSize) {
 
 bool CommandParser::IsWriteCmdValid(const string& cmd, size_t tokenSize) {
     if (cmd == WRITE_CMD && tokenSize == 3) return true;
+    return false;
+}
+
+bool CommandParser::IsEraseCmdValid(const string& cmd, size_t tokenSize) {
+    if (cmd.find(ERASE_CMD) != string::npos && tokenSize == 3) return true;
     return false;
 }
 
@@ -49,27 +55,11 @@ bool CommandParser::doParse(const string& fullCmd) {
     command = tokens[0];
     if (IsVaildCommand(command, tokens.size()) == false) return false;
     if (tokens.size() > 1) {
-        try {
-            lba = stringToUnsignedInt(tokens[1]);
-        }
-        catch (const std::exception& e) {
-            cout << e.what() << endl;
-            return false;
-        }
+        if (setLbaFromToken(tokens[1]) == false) return false;
     }
     
     if (tokens.size() > 2) {
-        if (command == WRITE_CMD) {
-            if (IsValidWriteData(tokens[2]) == false) return false;
-        }
-
-        try {
-            data = stringToUnsignedInt(tokens[2]);
-        }
-        catch (const std::exception& e) {
-            cout << e.what() << endl;
-            return false;
-        }
+        if (setDataFromToken(tokens[2]) == false) return false;
     }
 
     return true;
@@ -89,3 +79,28 @@ bool CommandParser::IsValidWriteData(const string& data) {
     return true;
 }
 
+bool CommandParser::setLbaFromToken(const string& strLba) {
+    try {
+        lba = stringToUnsignedInt(strLba);
+    }
+    catch (const std::exception& e) {
+        cout << e.what() << endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool CommandParser::setDataFromToken(const string& strData) {
+    if (command == WRITE_CMD && IsValidWriteData(strData) == false) return false;
+
+    try {
+        data = stringToUnsignedInt(strData);
+    }
+    catch (const std::exception& e) {
+        cout << e.what() << endl;
+        return false;
+    }
+
+    return true;
+}

--- a/TestShell/commandParser.h
+++ b/TestShell/commandParser.h
@@ -14,8 +14,12 @@ private:
     bool IsVaildCommand(const string& cmd, size_t tokenSize);
     bool doParse(const string& cmd);
     bool IsWriteCmdValid(const string& cmd, size_t tokenSize);
+    bool IsEraseCmdValid(const string& cmd, size_t tokenSize);
     bool IsReadCmdValid(const string& cmd, size_t tokenSize);
     bool IsValidWriteData(const string& data);
+
+    bool setLbaFromToken(const string& strLba);
+    bool setDataFromToken(const string& strData);
 
     IExecutor* executor;
     string command = "";
@@ -23,7 +27,10 @@ private:
     DATA data = -1;
 
     std::unordered_set<string> cmd_set = {
-        READ_CMD, WRITE_CMD, FULL_READ_CMD, FULL_WRITE_CMD, HELP_CMD, EXIT_CMD,
+        READ_CMD, FULL_READ_CMD,
+        WRITE_CMD,FULL_WRITE_CMD,
+        ERASE_CMD, ERASE_RANGE_CMD,
+        HELP_CMD, EXIT_CMD,
         FIRST_SCRIPT_SHORT_NAME, SECOND_SCRIPT_SHORT_NAME, THIRD_SCRIPT_SHORT_NAME,
         FIRST_SCRIPT_FULL_NAME, SECOND_SCRIPT_FULL_NAME, THIRD_SCRIPT_FULL_NAME,
     };

--- a/TestShell/commandParser_test.cpp
+++ b/TestShell/commandParser_test.cpp
@@ -8,6 +8,7 @@ class MockSsdApp : public ISsdApp {
 public:
     MOCK_METHOD(DATA, Read, (LBA), (override));
     MOCK_METHOD(bool, Write, (LBA, DATA), (override));
+    MOCK_METHOD(bool, Erase, (LBA, SIZE), (override));
 };
 
 class CommandParserFixture : public Test {
@@ -39,4 +40,13 @@ TEST_F(CommandParserFixture, fullreadCommand) {
 
     CheckParseCommand(FULL_READ_CMD);
 }
+
+TEST_F(CommandParserFixture, eraseCommand) {
+    EXPECT_CALL(mock_app, Erase)
+        .Times(1)
+        .WillOnce(Return(true));
+
+    CheckParseCommand(ERASE_CMD, 0, 2);
+}
+
 #endif

--- a/TestShell/compositExecutor_test.cpp
+++ b/TestShell/compositExecutor_test.cpp
@@ -8,6 +8,7 @@ class MockSsdApp : public ISsdApp {
 public:
 	MOCK_METHOD(DATA, Read, (LBA), (override));
 	MOCK_METHOD(bool, Write, (LBA, DATA), (override));
+	MOCK_METHOD(bool, Erase, (LBA, SIZE), (override));
 };
 
 class MockWriter : public Writer

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -108,8 +108,6 @@ bool RangeEraser::execute(ISsdApp* app, LBA startLba, LBA endLba)
 {
 	SIZE size = endLba - startLba + 1;
 
-	app->Erase(startLba, size);
-
-	cout << "[Erase_range] Done\n";
+	Eraser::execute(app, startLba, size);
 	return true;
 }

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -91,11 +91,8 @@ bool Helper::execute(ISsdApp* app, LBA lba, DATA data)
 	return true;
 }
 
-bool Exiter::execute(ISsdApp* app, LBA lba, SIZE size)
+bool Exiter::execute(ISsdApp* app, LBA lba, DATA data)
 {
-	app->Erase(lba, size);
-
-	cout << "[Erase] Done\n";
 	return true;
 }
 

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -14,6 +14,8 @@ IExecutor* ExecutorFactory::createExecutor(const string command)
 	if (command == FULL_WRITE_CMD) return new FullWriter();
 	if (command == READ_CMD) return new Reader();
 	if (command == FULL_READ_CMD) return new FullReader();
+	if (command == ERASE_CMD) return new Eraser();
+	if (command == ERASE_RANGE_CMD) return new RangeEraser();
 	if (command == HELP_CMD) return new Helper();
 	if (command == EXIT_CMD) return new Exiter();
 	if (command == FIRST_SCRIPT_SHORT_NAME || command == FIRST_SCRIPT_FULL_NAME)return new FullWriteAndReadCompare(new Writer(), new Reader());
@@ -89,8 +91,28 @@ bool Helper::execute(ISsdApp* app, LBA lba, DATA data)
 	return true;
 }
 
-bool Exiter::execute(ISsdApp* app, LBA lba, DATA data)
+bool Exiter::execute(ISsdApp* app, LBA lba, SIZE size)
 {
+	app->Erase(lba, size);
+
+	cout << "[Erase] Done\n";
 	return true;
 }
 
+bool Eraser::execute(ISsdApp* app, LBA startLba, SIZE size)
+{
+	app->Erase(startLba, size);
+
+	cout << "[Eraser] Done\n";
+	return true;
+}
+
+bool RangeEraser::execute(ISsdApp* app, LBA startLba, LBA endLba)
+{
+	SIZE size = endLba - startLba + 1;
+
+	app->Erase(startLba, size);
+
+	cout << "[Erase_range] Done\n";
+	return true;
+}

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -54,10 +54,10 @@ public:
 
 class Eraser : public IExecutor {
 public:
-	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+	bool execute(ISsdApp* app, LBA lba = 0, SIZE size = 0) override;
 };
 
-class RangeEraser : public IExecutor {
+class RangeEraser : public Eraser {
 public:
-	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+	bool execute(ISsdApp* app, LBA startLba = 0, LBA endLba = 0) override;
 };

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -51,3 +51,13 @@ class Exiter : public IExecutor {
 public:
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 };
+
+class Eraser : public IExecutor {
+public:
+	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+};
+
+class RangeEraser : public IExecutor {
+public:
+	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+};

--- a/TestShell/executor_test.cpp
+++ b/TestShell/executor_test.cpp
@@ -10,6 +10,7 @@ class MockSsdApp : public ISsdApp {
 public:
 	MOCK_METHOD(DATA, Read, (LBA), (override));
 	MOCK_METHOD(bool, Write, (LBA, DATA), (override));
+	MOCK_METHOD(bool, Erase, (LBA, SIZE), (override));
 };
 
 class ExecutorTestFixture : public Test {
@@ -64,6 +65,14 @@ TEST_F(ExecutorTestFixture, fullreadCommandTest) {
 		.WillOnce(Return(NO_DATA));
 
 	checkExecute(FULL_READ_CMD, 0, 0, NO_DATA);
+}
+
+TEST_F(ExecutorTestFixture, eraseCommandTest) {
+	EXPECT_CALL(mock_app, Erase)
+		.Times(1)
+		.WillOnce(Return(true));
+
+	checkExecute(ERASE_CMD, 0, 2);
 }
 
 #endif

--- a/TestShell/global_config.h
+++ b/TestShell/global_config.h
@@ -5,6 +5,7 @@
 
 using DATA = unsigned int;
 using LBA = unsigned int;
+using SIZE = unsigned int;
 
 using std::string;
 
@@ -12,10 +13,13 @@ const string READ_CMD = "read";
 const string WRITE_CMD = "write";
 const string SEND_READ_CMD = "R";
 const string SEND_WRITE_CMD = "W";
+const string SEND_ERASE_CMD = "E";
 const string FULL_READ_CMD = "fullread";
 const string FULL_WRITE_CMD = "fullwrite";
 const string HELP_CMD = "help";
 const string EXIT_CMD = "exit";
+const string ERASE_CMD = "erase";
+const string ERASE_RANGE_CMD = "erase_range";
 
 const string FIRST_SCRIPT_SHORT_NAME = "1_";
 const string FIRST_SCRIPT_FULL_NAME = "1_FullWriteAndReadCompare";

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -12,6 +12,7 @@ typedef unsigned int u32;
 interface ISsdApp {
 	virtual u32 Read(u32 lba) = 0;
 	virtual bool Write(u32 lba, u32 data) = 0;
+	virtual bool Erase(u32 lba, u32 size) = 0;
 };
 
 interface IExecutor {

--- a/TestShell/shellInterface_test.cpp
+++ b/TestShell/shellInterface_test.cpp
@@ -25,7 +25,7 @@ public:
 class ShellFixture : public Test {
 public:
     NiceMock<MockCommandParser> mockCommandParser;
-    NiceMock < MockSsdApp> mock_app;
+    NiceMock<MockSsdApp> mock_app;
     class Shell shell;
     class Shell mockshell {&mockCommandParser};
     string EXIT_CMD = "exit\n";

--- a/TestShell/shellInterface_test.cpp
+++ b/TestShell/shellInterface_test.cpp
@@ -19,12 +19,13 @@ class MockSsdApp : public ISsdApp {
 public:
     MOCK_METHOD(DATA, Read, (LBA), (override));
     MOCK_METHOD(bool, Write, (LBA, DATA), (override));
+    MOCK_METHOD(bool, Erase, (LBA, SIZE), (override));
 };
 
 class ShellFixture : public Test {
 public:
     NiceMock<MockCommandParser> mockCommandParser;
-    MockSsdApp mock_app;
+    NiceMock < MockSsdApp> mock_app;
     class Shell shell;
     class Shell mockshell {&mockCommandParser};
     string EXIT_CMD = "exit\n";

--- a/TestShell/ssdApp.cpp
+++ b/TestShell/ssdApp.cpp
@@ -15,6 +15,12 @@ bool SsdApp::Write(LBA lba, DATA data) {
 	return true;
 }
 
+bool SsdApp::Erase(LBA lba, SIZE size) {
+	string sendEraseString = makeExecuteCmd(SEND_ERASE_CMD, lba, size);
+	system(sendEraseString.c_str());
+	return true;
+}
+
 SsdApp* SsdApp::getInstance()
 {
 	static SsdApp instance;

--- a/TestShell/ssdApp.h
+++ b/TestShell/ssdApp.h
@@ -9,7 +9,7 @@ public:
 
 	bool Write(LBA lba, DATA data) override;
 
-	bool Erase(LBA lba, SIZE size);
+	bool Erase(LBA lba, SIZE size) override;
 
 	static SsdApp* getInstance();
 

--- a/TestShell/ssdApp.h
+++ b/TestShell/ssdApp.h
@@ -9,6 +9,8 @@ public:
 
 	bool Write(LBA lba, DATA data) override;
 
+	bool Erase(LBA lba, SIZE size);
+
 	static SsdApp* getInstance();
 
 private:

--- a/TestShell/utils.cpp
+++ b/TestShell/utils.cpp
@@ -14,10 +14,13 @@ const string makeExecuteCmd(string cmd, LBA lba, DATA data) {
 	if (cmd == SEND_WRITE_CMD) {
 		oss << " " << DataToHexString(data);
 	}
+	else if (cmd == SEND_ERASE_CMD) {
+		oss << " " << data;
+	}
 	string commandStr = oss.str();
-#ifdef _DEBUG
+//#ifdef _DEBUG
 	cout << commandStr << endl;
-#endif
+//#endif
 	return commandStr;
 }
 


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #124

## 제목
- [PREFIX] TestShell app supports erase, erase_range command

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- TestShell app이 erase와 erase_range 명령어를 지원합니다.
- 사용 예:
- erase 0 4 : 0번 lba부터 4 size만큼 삭제
- erase_range 33 53 : 33번 lba부터 55번 lba까지 삭제
