### PR TITLE
[#158][feature] erase implementation

### DIFF
--- a/TestShell/commandParser.cpp
+++ b/TestShell/commandParser.cpp
@@ -22,11 +22,12 @@ bool CommandParser::ExecuteSsdUsingParsedCommand(ISsdApp* app) {
 }
 
 bool CommandParser::IsVaildCommand(const string& cmd, size_t tokenSize) {
+    // TODO: need to refactor
     if (cmd_set.find(cmd) != cmd_set.end()) {
         if (IsWriteCmdValid(cmd, tokenSize)) return true;
         else if (IsReadCmdValid(cmd, tokenSize)) return true;
         else if (IsEraseCmdValid(cmd, tokenSize)) return true;
-        else if (tokenSize == 1) return true;
+        else if ((cmd != WRITE_CMD && cmd != READ_CMD) && tokenSize == 1) return true;
         return false;
     }
     return false;

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -64,6 +64,8 @@ public:
 class Eraser : public IExecutor {
 public:
 	bool execute(ISsdApp* app, LBA lba = 0, SIZE size = 0) override;
+private:
+	bool sendEraseMessageWithCalculatedSize(ISsdApp* app, LBA startLba, SIZE size);
 };
 
 class RangeEraser : public Eraser {

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -66,6 +66,7 @@ public:
 	bool execute(ISsdApp* app, LBA lba = 0, SIZE size = 0) override;
 private:
 	bool sendEraseMessageWithCalculatedSize(ISsdApp* app, LBA startLba, SIZE size);
+	std::pair<LBA, SIZE> calculateStartLbaAndSize(LBA lba, SIZE size);
 };
 
 class RangeEraser : public Eraser {

--- a/TestShell/global_config.h
+++ b/TestShell/global_config.h
@@ -35,4 +35,5 @@ const DATA TEST_DATA = 0x12345678;
 const DATA NO_DATA = 0x00000000;
 
 const int DATA_NUM_DIGIT = 8;
+const int MAX_SEND_ERASE_SIZE_FOR_ONE_TIME = 10;
 const string EXE_FILE_NAME = "..\\x64\\Release\\SSD.exe";


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #158

## 제목
- [#158][feature] erase implementation

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- erase, erase_range 명령어의 수행 범위를 다양하게 지원합니다. (size를 10씩 끊어서 erase cmd 수행)
- erase 3 100
- erase 55 -43
- erase 62 -200
- erase_range 5 89
- erase_range 76 23
- erase_range 72 23
