### PR TITLE
[#177][Refactor] Separate Output Function from Executors

### DIFF
--- a/TestShell/commandParser_test.cpp
+++ b/TestShell/commandParser_test.cpp
@@ -29,15 +29,15 @@ TEST_F(CommandParserFixture, HelpCommand) {
 TEST_F(CommandParserFixture, FullwriteCommand) {
     EXPECT_CALL(mock_app, Write)
         .Times(SSD_MAX_SIZE)
-        .WillOnce(Return(true));
+        .WillRepeatedly(Return(true));
 
     CheckParseCommand(FULL_WRITE_CMD, 0, TEST_DATA);
 }
 
-TEST_F(CommandParserFixture, fullreadCommand) {
+TEST_F(CommandParserFixture, FullreadCommand) {
     EXPECT_CALL(mock_app, Read)
         .Times(SSD_MAX_SIZE)
-        .WillOnce(Return(true));
+        .WillRepeatedly(Return(true));
 
     CheckParseCommand(FULL_READ_CMD);
 }

--- a/TestShell/compositExecutor.cpp
+++ b/TestShell/compositExecutor.cpp
@@ -7,18 +7,17 @@
 #include <random>
 #endif
 
-bool CompositExecutor::ReadCompare(ISsdApp* app, LBA lba, DATA expectedData)
+bool CompositExecutor::PrintPass(void)
 {
-	if (comparer->execute(app, lba, expectedData)) return true;
-
-#ifndef _DEBUG
-	cout << "FAIL\n";
-	return false;
-#endif
-
+	cout << "PASS\n";
 	return true;
 }
 
+bool CompositExecutor::PrintFail(void)
+{
+	cout << "FAIL\n";
+	return false;
+}
 
 bool FullWriteAndReadCompare::execute(ISsdApp* app, LBA lba, DATA data)
 {
@@ -35,12 +34,11 @@ bool FullWriteAndReadCompare::execute(ISsdApp* app, LBA lba, DATA data)
 
 		for (LBA readLba = startLba; readLba < endLba; readLba++)
 		{
-			if (!ReadCompare(app, readLba, writeData)) return false;
+			if (!comparer->execute(app, readLba, writeData)) return CompositExecutor::PrintFail();
 		}
 	}
 
-	cout << "PASS\n";
-	return true;
+	return CompositExecutor::PrintPass();
 }
 
 bool PartialLBAWrite::execute(ISsdApp* app, LBA lba, DATA data)
@@ -60,12 +58,11 @@ bool PartialLBAWrite::execute(ISsdApp* app, LBA lba, DATA data)
 
 		for (DATA readLba = readStartLba; readLba < readEndLba; readLba++)
 		{
-			if (!ReadCompare(app, readLba, writeData)) return false;
+			if (!comparer->execute(app, readLba, writeData)) return CompositExecutor::PrintFail();
 		}
 	}
 
-	cout << "PASS\n";
-	return true;
+	return CompositExecutor::PrintPass();
 }
 
 bool WriteReadAging::execute(ISsdApp* app, LBA lba, DATA data)
@@ -90,12 +87,11 @@ bool WriteReadAging::execute(ISsdApp* app, LBA lba, DATA data)
 
 		for (int index = 0; index < NUM_LBA_PER_LOOP; index++)
 		{
-			if (!ReadCompare(app, lbaRange[index], writeData[index])) return false;
+			if (!comparer->execute(app, lbaRange[index], writeData[index])) return CompositExecutor::PrintFail();
 		}
 	}
 
-	cout << "PASS\n";
-	return true;
+	return CompositExecutor::PrintPass();
 }
 
 bool EraseAndWriteAging::execute(ISsdApp* app, LBA lba, DATA data)
@@ -121,12 +117,11 @@ bool EraseAndWriteAging::execute(ISsdApp* app, LBA lba, DATA data)
 
 			for (LBA readLba = startLba; readLba < endLba; readLba++)
 			{
-				if (!ReadCompare(app, readLba, erasedData)) return false;
+				if (!comparer->execute(app, readLba, erasedData)) return CompositExecutor::PrintFail();
 			}
 		}
 	}
 
-	cout << "PASS\n";
-	return true;
+	return CompositExecutor::PrintPass();
 }
 

--- a/TestShell/compositExecutor.h
+++ b/TestShell/compositExecutor.h
@@ -10,9 +10,11 @@ class CompositExecutor : public IExecutor
 public:
 	CompositExecutor() = default;
 	CompositExecutor(Writer* writer, Comparer* comparer) : writer{ writer }, comparer { comparer } {}
-	bool ReadCompare(ISsdApp* app, LBA lba, DATA expectedData);
 
 protected:
+	static bool PrintPass(void);
+	static bool PrintFail(void);
+
 	Writer* writer;
 	Comparer* comparer;
 };

--- a/TestShell/compositExecutor_test.cpp
+++ b/TestShell/compositExecutor_test.cpp
@@ -63,7 +63,8 @@ TEST_F(CompositExecutorFixture, CompositExecutor1CheckMockReadWriteMaxTimes) {
 		.Times(FIRST_TEST_SCRIPT_MAX_IO_TIMES);
 
 	EXPECT_CALL(mockComparer, execute)
-		.Times(FIRST_TEST_SCRIPT_MAX_IO_TIMES);
+		.Times(FIRST_TEST_SCRIPT_MAX_IO_TIMES)
+		.WillRepeatedly(Return(true));
 
 	mockFirstApp.execute(&mockSsdApp, 0, 0);
 }
@@ -73,7 +74,8 @@ TEST_F(CompositExecutorFixture, CompositExecutor2CheckMockReadWriteMaxTimes) {
 		.Times(SECOND_TEST_SCRIPT_MAX_IO_TIMES);
 
 	EXPECT_CALL(mockComparer, execute)
-		.Times(SECOND_TEST_SCRIPT_MAX_IO_TIMES);
+		.Times(SECOND_TEST_SCRIPT_MAX_IO_TIMES)
+		.WillRepeatedly(Return(true));
 
 	mockSecondApp.execute(&mockSsdApp, 0, 0);
 }
@@ -83,7 +85,8 @@ TEST_F(CompositExecutorFixture, CompositExecutor3CheckMockReadWriteMaxTimes) {
 		.Times(THIRD_TEST_SCRIPT_MAX_IO_TIMES);
 
 	EXPECT_CALL(mockComparer, execute)
-		.Times(THIRD_TEST_SCRIPT_MAX_IO_TIMES);
+		.Times(THIRD_TEST_SCRIPT_MAX_IO_TIMES)
+		.WillRepeatedly(Return(true));
 
 	mockThirdApp.execute(&mockSsdApp, 0, 0);
 }

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -8,6 +8,12 @@ public:
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
 };
 
+class OuputDecoratedWriter : public Writer
+{
+public:
+	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+};
+
 class FullWriter : public Writer
 {
 public:
@@ -24,7 +30,13 @@ private:
 	const string OUTPUT_NAME = "ssd_output.txt";
 };
 
-class FullReader : public Reader
+class OuputDecoratedReader : public Reader
+{
+public:
+	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+};
+
+class FullReader : public OuputDecoratedReader
 {
 public:
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
@@ -56,12 +68,14 @@ private:
 		"exit: 필요 파라미터 NONE - 하려던 거 끝내고 바로 종료한다\n";
 };
 
-class Exiter : public IExecutor {
+class Exiter : public IExecutor
+{
 public:
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 };
 
-class Eraser : public IExecutor {
+class Eraser : public IExecutor
+{
 public:
 	bool execute(ISsdApp* app, LBA lba = 0, SIZE size = 0) override;
 private:
@@ -69,12 +83,14 @@ private:
 	std::pair<LBA, SIZE> calculateStartLbaAndSize(LBA lba, SIZE size);
 };
 
-class RangeEraser : public Eraser {
+class RangeEraser : public Eraser
+{
 public:
 	bool execute(ISsdApp* app, LBA startLba = 0, LBA endLba = 0) override;
 };
 
-class Flusher : public IExecutor {
+class Flusher : public IExecutor
+{
 public:
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 };

--- a/TestShell/executor_test.cpp
+++ b/TestShell/executor_test.cpp
@@ -43,11 +43,10 @@ TEST_F(ExecutorTestFixture, writeCommandTest) {
 	checkExecute(WRITE_CMD, TEST_LBA, TEST_DATA);
 }
 
-TEST_F(ExecutorTestFixture, fullWriteCommandTest) {
+TEST_F(ExecutorTestFixture, fullwriteCommandTest) {
 	EXPECT_CALL(mock_app, Write)
 		.Times(SSD_MAX_SIZE)
-		.WillOnce(Return(true));
-	(Return(true));
+		.WillRepeatedly(Return(true));
 	
 	checkExecute(FULL_WRITE_CMD, 0, TEST_DATA);
 }
@@ -63,7 +62,7 @@ TEST_F(ExecutorTestFixture, readNonWriteTest) {
 TEST_F(ExecutorTestFixture, fullreadCommandTest) {
 	EXPECT_CALL(mock_app, Read)
 		.Times(SSD_MAX_SIZE)
-		.WillOnce(Return(NO_DATA));
+		.WillRepeatedly(Return(NO_DATA));
 
 	checkExecute(FULL_READ_CMD, 0, 0, NO_DATA);
 }

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -6,7 +6,11 @@ using namespace std;
 
 //#define LOG_DEBUG
 
+#ifdef _DEBUG
+#define SHELL_LOG(...)
+#else
 #define SHELL_LOG(...) Logger::GetInstance().Log(__FUNCTION__, __VA_ARGS__)
+#endif
 
 class LogFile {
 public:


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #177

## 제목
- [#177][Refactor] Separate Output Function from Executors

## 프로젝트
- [ ] SSD
- [x] TestShell
- [x] TestScript

## 변경 사항
- [#177][Refactor] Add OutputDecoratedWriter and Reader
- [#177][Refactor] Define PrintPass() and PrintFail() for Simple Chain of Responsibility Pattern