### PR TITLE
[#188][Refactor] valid check is done by executor, no more commandParser

### DIFF
--- a/TestShell/commandParser.h
+++ b/TestShell/commandParser.h
@@ -7,17 +7,11 @@ using namespace std;
 
 class CommandParser : public ICommandParserBridge {
 public:
+    bool IsVaildCommand(const string& cmd);
     bool ParseCommand(const string& cmd) override;
     bool ExecuteSsdUsingParsedCommand(ISsdApp* app) override;
-
 private:
-    bool IsVaildCommand(const string& cmd, size_t tokenSize);
-    bool doParse(const string& cmd);
-    bool IsWriteCmdValid(const string& cmd, size_t tokenSize);
-    bool IsFullWriteCmdValid(const string& cmd, size_t tokenSize);
-    bool IsEraseCmdValid(const string& cmd, size_t tokenSize);
-    bool IsReadCmdValid(const string& cmd, size_t tokenSize);
-    bool IsValidWriteData(const string& data);
+    bool doParse(const vector<string>& tokens);
 
     bool setLbaFromToken(const string& strLba);
     bool setDataFromToken(const string& strData);

--- a/TestShell/compositExecutor.h
+++ b/TestShell/compositExecutor.h
@@ -10,7 +10,7 @@ class CompositExecutor : public IExecutor
 public:
 	CompositExecutor() = default;
 	CompositExecutor(Writer* writer, Comparer* comparer) : writer{ writer }, comparer { comparer } {}
-
+	bool IsValidCommand(const vector<string>& tokens) override { return true; }
 protected:
 	static bool PrintPass(void);
 	static bool PrintFail(void);

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -37,11 +37,38 @@ bool Writer::execute(ISsdApp* app, LBA lba, DATA data)
 	return true;
 }
 
+bool OuputDecoratedWriter::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == WRITE_CMD && tokens.size() == NEEDED_TOKEN_COUNT) {
+		if (IsValidWriteData(tokens[DATA_IDX])) return true;
+		return false;
+	}
+	return false;
+}
+
+bool OuputDecoratedWriter::IsValidWriteData(const string& data) {
+	if (data.size() != 10) return false;
+
+	if (!(data[0] == '0' && (data[1] == 'x' || data[1] == 'X')))
+		return false;
+
+	for (size_t i = 2; i < 10; ++i) {
+		if (!std::isxdigit(static_cast<unsigned char>(data[i])))
+			return false;
+	}
+
+	return true;
+}
+
 bool OuputDecoratedWriter::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	if (!Writer::execute(app, lba, data)) return false;
 	cout << "[Write] Done\n";
 	return true;
+}
+
+bool FullWriter::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
 }
 
 bool FullWriter::execute(ISsdApp* app, LBA lba, DATA data)
@@ -79,11 +106,21 @@ string Reader::GetResultFromFile(void)
 	return result;
 }
 
+bool OuputDecoratedReader::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
+}
+
 bool OuputDecoratedReader::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	if (!Reader::execute(app, lba, data)) return false;
 	cout << "[Read] LBA " << lba << " : " << GetResultFromFile() << "\n";
 	return true;
+}
+
+bool FullReader::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
 }
 
 bool FullReader::execute(ISsdApp* app, LBA lba, DATA data)
@@ -114,6 +151,11 @@ bool Comparer::Compare(const DATA expectedData, const string &readResult)
 	return false;
 }
 
+bool Helper::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
+}
+
 bool Helper::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	cout << this->HELP_DESCRIPTION;
@@ -121,9 +163,19 @@ bool Helper::execute(ISsdApp* app, LBA lba, DATA data)
 	return true;
 }
 
+bool Exiter::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
+}
+
 bool Exiter::execute(ISsdApp* app, LBA lba, DATA data)
 {
 	return true;
+}
+
+bool Eraser::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
 }
 
 bool Eraser::execute(ISsdApp* app, LBA startLba, SIZE size)
@@ -177,6 +229,11 @@ bool Eraser::sendEraseMessageWithCalculatedSize(ISsdApp* app, LBA startLba, SIZE
 	return true;
 }
 
+bool RangeEraser::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
+}
+
 bool RangeEraser::execute(ISsdApp* app, LBA startLba, LBA endLba)
 {
 	LBA changedStartLba, changedEndLba;
@@ -185,6 +242,11 @@ bool RangeEraser::execute(ISsdApp* app, LBA startLba, LBA endLba)
 	SIZE size = changedEndLba - changedStartLba + 1;
 	Eraser::execute(app, changedStartLba, size);
 	return true;
+}
+
+bool Flusher::IsValidCommand(const vector<string>& tokens) {
+	if (tokens[CMD_IDX] == CMD && tokens.size() == NEEDED_TOKEN_COUNT) return true;
+	return false;
 }
 
 bool Flusher::execute(ISsdApp* app, LBA lba, DATA data)

--- a/TestShell/executor.h
+++ b/TestShell/executor.h
@@ -11,13 +11,22 @@ public:
 class OuputDecoratedWriter : public Writer
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+private:
+	bool IsValidWriteData(const string& data);
+	const string CMD = WRITE_CMD;
+	const int NEEDED_TOKEN_COUNT = 3;
 };
 
 class FullWriter : public Writer
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+private:
+	const string CMD = FULL_WRITE_CMD;
+	const int NEEDED_TOKEN_COUNT = 2;
 };
 
 class Reader : public IExecutor
@@ -33,13 +42,21 @@ private:
 class OuputDecoratedReader : public Reader
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+private:
+	const string CMD = READ_CMD;
+	const int NEEDED_TOKEN_COUNT = 2;
 };
 
 class FullReader : public OuputDecoratedReader
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba, DATA data) override;
+private:
+	const string CMD = FULL_READ_CMD;
+	const int NEEDED_TOKEN_COUNT = 1;
 };
 
 class Comparer : public Reader
@@ -54,6 +71,7 @@ private:
 class Helper : public IExecutor
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
 private:
 	const std::string HELP_DESCRIPTION =
@@ -66,31 +84,48 @@ private:
 		"fullread: 필요 파라미터 NONE - ssd의 모든 cell의 값을 읽어온다\n"
 		"help: 필요 파라미터 NONE - ssd에 필요한 command 등 모든 정보에 대한 도움말을 요청한다\n"
 		"exit: 필요 파라미터 NONE - 하려던 거 끝내고 바로 종료한다\n";
+	const string CMD = HELP_CMD;
+	const int NEEDED_TOKEN_COUNT = 1;
 };
 
 class Exiter : public IExecutor
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+private:
+	const string CMD = EXIT_CMD;
+	const int NEEDED_TOKEN_COUNT = 1;
 };
 
 class Eraser : public IExecutor
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba = 0, SIZE size = 0) override;
 private:
 	bool sendEraseMessageWithCalculatedSize(ISsdApp* app, LBA startLba, SIZE size);
 	std::pair<LBA, SIZE> calculateStartLbaAndSize(LBA lba, SIZE size);
+	const string CMD = ERASE_CMD;
+	const int NEEDED_TOKEN_COUNT = 3;
 };
 
 class RangeEraser : public Eraser
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA startLba = 0, LBA endLba = 0) override;
+private:
+	const string CMD = ERASE_RANGE_CMD;
+	const int NEEDED_TOKEN_COUNT = 3;
 };
 
 class Flusher : public IExecutor
 {
 public:
+	bool IsValidCommand(const vector<string>& tokens) override;
 	bool execute(ISsdApp* app, LBA lba = 0, DATA data = 0) override;
+private:
+	const string CMD = FLUSH_CMD;
+	const int NEEDED_TOKEN_COUNT = 1;
 };

--- a/TestShell/executor_test.cpp
+++ b/TestShell/executor_test.cpp
@@ -19,8 +19,7 @@ public:
 	void checkExecute(string cmd = "", LBA lba = 0, DATA data = 0, DATA expect_data = 0) {
 		executor = ExecutorFactory().createExecutor(cmd);
 
-		bool ret = executor->execute(&mock_app, lba, data);
-		EXPECT_TRUE(ret);
+		EXPECT_TRUE(executor->execute(&mock_app, lba, data));
 	}
 
 	MockSsdApp mock_app;

--- a/TestShell/global_config.h
+++ b/TestShell/global_config.h
@@ -43,6 +43,10 @@ const SIZE TEST_MINUS_SIZE = -20;
 const DATA TEST_DATA = 0x12345678;
 const DATA NO_DATA = 0x00000000;
 
+const int CMD_IDX = 0;
+const int LBA_IDX = 1;
+const int DATA_IDX = 2;
+
 const int DATA_NUM_DIGIT = 8;
 const int MAX_SEND_ERASE_SIZE_FOR_ONE_TIME = 10;
 

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <string>
+#include <vector>
 
 using std::string;
+using std::vector;
 
 #define interface struct
 
@@ -16,7 +18,8 @@ interface ISsdApp {
 	virtual bool Flush() = 0;
 };
 
-interface IExecutor {
+interface IExecutor{
+	virtual bool IsValidCommand(const vector<string>& tokens) { return false; }
 	virtual bool execute(ISsdApp* pApp = nullptr, u32 lba = 0, u32 data = 0) = 0;
 };
 


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #188

## 제목
- [#188][Refactor] valid check is done by executor, no more commandParser

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- 템플릿 메서드 패턴을 활용하여 더 이상 CommandParser가 직접 cmd valid checking을 하지 않고 각각의 executor에서 valid check을 하도록 변경했습니다.
- UT 100% passed
- I have checked using 1_, 2_, 3_ script command.
- I have checked using shell command
