### PR TITLE
[#179][REFACTOR] test_shell: logger class refactoring

### DIFF
--- a/TestShell/logger.cpp
+++ b/TestShell/logger.cpp
@@ -21,6 +21,7 @@ void LogFile::SetLogFile(const string& filename) {
     if (logFile.is_open())
         logFile.close();
     logFile.open(filename, ios::out | ios::app);
+    SetLatestName(filename);
 }
 /*
 void LogFile::SetName(const std::string& filename) {
@@ -32,11 +33,11 @@ string LogFile::GetName(void) {
 }
 */
 void LogFile::SetLatestName(const std::string& filename) {
-    untilLogName = filename;
+    latestLogName = filename;
 }
 
-string LogFile::GetLatestlName(void) {
-    return untilLogName;
+string LogFile::GetLatestName(void) {
+    return latestLogName;
 }
 
 void LogFile::SetUntilName(const std::string& filename) {
@@ -94,7 +95,9 @@ string UntilLogState::MakeUntilFileName(void) {
 }
 
 void UntilLogState::SaveUntilLogger(LogFile& logfile, const std::string& newName) {
-    string oldName = logfile.GetLatestlName();
+    string oldName = logfile.GetLatestName();
+
+    cout << __FUNCTION__ << endl;
 
     if (std::rename(oldName.c_str(), newName.c_str()) != 0) {
         //cout << "Rename Error" << endl;
@@ -121,7 +124,8 @@ void UntilLogState::SaveLog(LogFile& logfile, const std::string& message)
     }
 
     /* Change latest.log -> newUntilName.log */
-    SaveUntilLogger(logfile, MakeUntilFileName());
+    string newname = MakeUntilFileName();
+    SaveUntilLogger(logfile, newname);
 }
 
 bool UntilLogState::CheckChangeZip(LogFile& logfile) {
@@ -140,15 +144,17 @@ void LatestLogState::SaveLog(LogFile& logfile, const std::string& message)
 
     logfile.SetLogFile(LATEST_LOG_NAME);
 
-    WriteMessageToFile(logFile, message);
-
     needStateChange = CheckChangeUntil(logFile);
 
     if (needStateChange) {
         logfile.SetState(std::make_unique<UntilLogState>());
 
         logfile.SaveLog(message);
+
+        logfile.SetLogFile(LATEST_LOG_NAME);
     }
+
+    WriteMessageToFile(logFile, message);
 }
 
 void LatestLogState::WriteMessageToFile(ofstream& logfile, const std::string& message)

--- a/TestShell/logger.cpp
+++ b/TestShell/logger.cpp
@@ -5,6 +5,14 @@
 #include <string>
 #include "logger.h"
 
+void LogFile::Log(const std::string& message) {
+    state->SaveLog(*this, message);
+}
+
+void LogFile::SetState(std::unique_ptr<ILogFileState> newState) {
+    state = std::move(newState);
+}
+
 void LogFile::SetLogFile(const string& filename) {
     if (logFile.is_open())
         logFile.close();
@@ -19,7 +27,11 @@ string LogFile::GetName(void) {
     return fileName;
 }
 
-string ZipUntilLogger::GetZipFileName(const std::string& old_filename) {
+ofstream& LogFile::GetFile(void) {
+    return logFile;
+}
+
+string ZipUntilLogState::GetZipFileName(const std::string& old_filename) {
     string zipName = old_filename;
     const string target = ".log";
     const string replacement = ".zip";
@@ -31,7 +43,8 @@ string ZipUntilLogger::GetZipFileName(const std::string& old_filename) {
     return zipName;
 }
 
-void ZipUntilLogger::ZipUntilLogFile(const std::string& old_filename) {
+void ZipUntilLogState::ZipUntilLogFile(const std::string& old_filename) {
+    /*
     string newName = GetZipFileName(old_filename);
 
     if (logFile.is_open())
@@ -45,9 +58,10 @@ void ZipUntilLogger::ZipUntilLogFile(const std::string& old_filename) {
     SetName(newName);
 
     logFile.open(GetName(), ios::out | ios::app);
+    */
 }
 
-string UntilLogger::GetUntilFileName(void) {
+string UntilLogState::GetUntilFileName(void) {
     time_t now = time(nullptr);
     tm localTime{};
 
@@ -63,7 +77,8 @@ string UntilLogger::GetUntilFileName(void) {
     return oss.str();
 }
 
-void UntilLogger::SaveUntilLogger(const std::string& old_filename) {
+void UntilLogState::SaveUntilLogger(const std::string& old_filename) {
+#if 0
     string newName = GetUntilFileName();
 
     if (logFile.is_open())
@@ -80,13 +95,33 @@ void UntilLogger::SaveUntilLogger(const std::string& old_filename) {
     SetName(newName);
 
     logFile.open(GetName(), ios::out | ios::app);
+#endif
 }
 
-void Logger::CheckManageUntilLogFile(void) {
+void ZipUntilLogState::SaveLog(LogFile& logfile, const std::string& message)
+{
+    ofstream& logFile = logfile.GetFile();
+
+}
+
+void UntilLogState::SaveLog(LogFile& logfile,const std::string& message)
+{
+    ofstream& logFile = logfile.GetFile();
+}
+
+void LatestLogState::SaveLog(LogFile& logfile, const std::string& message)
+{
+    CheckManageUntilLogFile(logfile);
+}
+
+void LatestLogState::CheckManageUntilLogFile(LogFile& logfile) {
+    ofstream& logFile = logfile.GetFile();
+
     if (logFile.is_open() == false) {
-        SetLogFile(LATEST_LOG_NAME);
+        logfile.SetLogFile(LATEST_LOG_NAME);
     }
 
+    /*
     if (GetLatestLogSize() > MANAGE_FILE_SIZE) {
         if (logFile.is_open())
             logFile.close();
@@ -95,9 +130,11 @@ void Logger::CheckManageUntilLogFile(void) {
 
         SetLogFile(LATEST_LOG_NAME);
     }
+    */
 }
 
-int Logger::GetLatestLogSize(void) {
+int LatestLogState::GetLatestLogSize(LogFile& logfile) {
+    ofstream& logFile = logfile.GetFile();
     return logFile.tellp();
 }
 

--- a/TestShell/logger.cpp
+++ b/TestShell/logger.cpp
@@ -51,7 +51,7 @@ ofstream& LogFile::GetFile(void) {
     return logFile;
 }
 
-string ZipUntilLogState::GetZipFileName(const std::string& old_filename) {
+string ZipUntilLogState::MakeZipFileName(const std::string& old_filename) {
     string zipName = old_filename;
     const string target = ".log";
     const string replacement = ".zip";
@@ -64,30 +64,20 @@ string ZipUntilLogState::GetZipFileName(const std::string& old_filename) {
 }
 
 void ZipUntilLogState::ZipUntilLogFile(const std::string& old_filename) {
-    /*
-    string newName = GetZipFileName(old_filename);
-
-    if (logFile.is_open())
-        logFile.close();
+    string newName = MakeZipFileName(old_filename);
 
     if (std::rename(old_filename.c_str(), newName.c_str()) != 0) {
-        cout << "Rename Error" << endl;
+        //cout << "Rename Error" << endl;
         return;
     }
-
-    SetName(newName);
-
-    logFile.open(GetName(), ios::out | ios::app);
-    */
 }
 
 void ZipUntilLogState::SaveLog(LogFile& logfile, const std::string& message)
 {
-    ofstream& logFile = logfile.GetFile();
-
+    ZipUntilLogFile(logfile.GetUntilName());
 }
 
-string UntilLogState::GetUntilFileName(void) {
+string UntilLogState::MakeUntilFileName(void) {
     time_t now = time(nullptr);
     tm localTime{};
 
@@ -119,6 +109,9 @@ void UntilLogState::SaveLog(LogFile& logfile, const std::string& message)
     ofstream& logFile = logfile.GetFile();
     bool needStateChange = 0;
 
+    if (logFile.is_open())
+        logFile.close();
+
     needStateChange = CheckChangeZip(logfile);
     if (needStateChange) {
         /* Change oldUntilName.log -> newZipUntilName.log */
@@ -127,11 +120,8 @@ void UntilLogState::SaveLog(LogFile& logfile, const std::string& message)
         logfile.SaveLog(message);
     }
 
-    if (logFile.is_open())
-        logFile.close();
-
     /* Change latest.log -> newUntilName.log */
-    SaveUntilLogger(logfile, GetUntilFileName());
+    SaveUntilLogger(logfile, MakeUntilFileName());
 }
 
 bool UntilLogState::CheckChangeZip(LogFile& logfile) {

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -86,7 +86,7 @@ private:
     int GetLatestLogSize(ofstream& logFile);
 };
 
-class Logger : public LogFile {
+class Logger {
 public:
     std::string GetCurrentTimeString(void);
 

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -37,7 +37,7 @@ public:
  //   void SetName(const std::string& filename);
  //   string GetName(void);
     void SetLatestName(const std::string& filename);
-    string GetLatestlName(void);
+    string GetLatestName(void);
 
     void SetUntilName(const std::string& filename);
     string GetUntilName(void);

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -60,7 +60,7 @@ public:
 
 private:
     void ZipUntilLogFile(const std::string& message);
-    string GetZipFileName(const std::string& old_filename);
+    string MakeZipFileName(const std::string& old_filename);
 };
 
 class UntilLogState : public ILogFileState {
@@ -70,7 +70,7 @@ public:
 private:
     bool CheckChangeZip(LogFile& logfile);
     void SaveUntilLogger(LogFile& logfile, const std::string& old_filename);
-    string GetUntilFileName(void);
+    string MakeUntilFileName(void);
 };
 
 class LatestLogState : public ILogFileState {

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -26,20 +26,29 @@ public:
 
 class LogFile {
 public:
-    void Log(const std::string& message);
+    LogFile();
+
+    void SaveLog(const std::string& message);
 
     void SetState(std::unique_ptr<ILogFileState> newState);
 
     void SetLogFile(const std::string& filename);
 
-    void SetName(const std::string& filename);
-    string GetName(void);
+ //   void SetName(const std::string& filename);
+ //   string GetName(void);
+    void SetLatestName(const std::string& filename);
+    string GetLatestlName(void);
+
+    void SetUntilName(const std::string& filename);
+    string GetUntilName(void);
 
     //void SetFile(const std::string& filename);
     std::ofstream& GetFile(void);
 
 private:
-    string fileName;
+    string latestLogName = {};
+    string untilLogName = {};
+    string zipLogName = {};
     std::ofstream logFile;
     std::unique_ptr<ILogFileState> state;
 
@@ -59,19 +68,22 @@ public:
     void SaveLog(LogFile& logfile, const std::string& message) override;
 
 private:
-    void SaveUntilLogger(const std::string& old_filename);
+    bool CheckChangeZip(LogFile& logfile);
+    void SaveUntilLogger(LogFile& logfile, const std::string& old_filename);
     string GetUntilFileName(void);
 };
 
 class LatestLogState : public ILogFileState {
 public:
     void SaveLog(LogFile& logfile, const std::string& message) override;
+
 private:
     const string LATEST_LOG_NAME = "latest.log";
     const int MANAGE_FILE_SIZE = 10 * 1024; // 10KB
-    void CheckManageUntilLogFile(LogFile& logfile);
+    void WriteMessageToFile(ofstream& logfile, const std::string& message);
+    bool CheckChangeUntil(ofstream& logfile);
 
-    int GetLatestLogSize(LogFile& logfile);
+    int GetLatestLogSize(ofstream& logFile);
 };
 
 class Logger : public LogFile {
@@ -83,11 +95,10 @@ public:
     template <typename... Args>
     void Log(const string& func, Args&&... args) {
         string result;
-        //CheckManageUntilLogFile();
 
         result = LogImpl(func, std::forward<Args>(args)...);
 
-        logFile.Log(result);
+        logFile.SaveLog(result);
     }
 private:
     template <typename T>


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #179

## 제목
- [#179][REFACTOR] test_shell: refactor logger class refactoring

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
logger class 에 너무 많은 책임이 있어, 책임을 분리하려고 합니다. logging 기능과 file 관리 분리
logger class code clean 작업을 수행합니다.
file 관리에는 state pattern을 적용합니다.

- 변경 전 구조 : logger에 너무 많은 기능이 몰려있고, logFile을 다른 file class 가 상속받는 구조
<img width="873" height="744" alt="image" src="https://github.com/user-attachments/assets/5a37aa6a-fc51-4885-a639-e242da4a47c7" />

- 최종 구조 diagram : state pattern을 추가하여 기존 logFIle 상속 의존성을 제거, 
- latestlogfilestate 를 추가하고, logger 기능을 각 state class에 이관함. logger는 log 만들 만드는 기능을 수행.
<img width="1149" height="752" alt="image" src="https://github.com/user-attachments/assets/370a83f1-e7d8-4c26-b7c0-9191e5a7e816" />

