### PR TITLE
[#208][Refactor] refactor ExecutorFactory and add Shell Log to Runner

### DIFF
--- a/TestShell/commandParser.cpp
+++ b/TestShell/commandParser.cpp
@@ -10,7 +10,7 @@ bool CommandParser::ParseCommand(const string& fullCmd) {
         return false;
     }
 
-    executor = ExecutorFactory().createExecutor(command);
+    executor = _factory->createExecutor(command);
     if (executor == nullptr) {
         print("INVALID COMMAND");
         return false;

--- a/TestShell/commandParser.h
+++ b/TestShell/commandParser.h
@@ -7,6 +7,7 @@ using namespace std;
 
 class CommandParser : public ICommandParserBridge {
 public:
+    CommandParser(IExecutorFactory* factory) : _factory{ factory } {}
     bool ParseCommand(const string& cmd) override;
     bool ExecuteSsdUsingParsedCommand(ISsdApp* app) override;
 private:
@@ -16,17 +17,9 @@ private:
     bool setDataFromToken(const string& strData);
     bool IsLbaRangeValid();
 
+    IExecutorFactory* _factory;
     IExecutor* executor;
     string command = "";
     LBA lba = 0;
     DATA data = -1;
-
-    std::unordered_set<string> cmd_set = {
-        READ_CMD, FULL_READ_CMD,
-        WRITE_CMD,FULL_WRITE_CMD,
-        ERASE_CMD, ERASE_RANGE_CMD,
-        HELP_CMD, EXIT_CMD, FLUSH_CMD,
-        FIRST_SCRIPT_SHORT_NAME, SECOND_SCRIPT_SHORT_NAME, THIRD_SCRIPT_SHORT_NAME, FOURTH_SCRIPT_SHORT_NAME,
-        FIRST_SCRIPT_FULL_NAME, SECOND_SCRIPT_FULL_NAME, THIRD_SCRIPT_FULL_NAME, FOURTH_SCRIPT_FULL_NAME,
-    };
 };

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -11,22 +11,36 @@
 using namespace std;
 
 const unordered_map<string, CompositExecutorFactory::Creator> CompositExecutorFactory::factoryMap = {
-	{FIRST_SCRIPT_SHORT_NAME, []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
-	{FIRST_SCRIPT_FULL_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{FIRST_SCRIPT_SHORT_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{FIRST_SCRIPT_FULL_NAME,   []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
 	{SECOND_SCRIPT_SHORT_NAME, []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
 	{SECOND_SCRIPT_FULL_NAME,  []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
-	{THIRD_SCRIPT_SHORT_NAME, []() { return new WriteReadAging(new Writer(), new Comparer()); }},
-	{THIRD_SCRIPT_FULL_NAME,  []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_SHORT_NAME,  []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_FULL_NAME,   []() { return new WriteReadAging(new Writer(), new Comparer()); }},
 	{FOURTH_SCRIPT_SHORT_NAME, []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 	{FOURTH_SCRIPT_FULL_NAME,  []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 };
 
 IExecutor* CompositExecutorFactory::createExecutor(const string& command) {
+	IExecutor* executor = getExecutorFromCache(command);
+	if (nullptr != executor) return executor;
+
+	executor = getExecutorFromMap(command);
+	if (nullptr != executor) return executor;
+	
+	return nullptr;
+}
+
+IExecutor* CompositExecutorFactory::getExecutorFromCache(const string& command) {
 	auto cacheIterator = executorCache.find(command);
 	if (cacheIterator != executorCache.end()) {
 		return cacheIterator->second.get();
 	}
+	
+	return nullptr;
+}
 
+IExecutor* CompositExecutorFactory::getExecutorFromMap(const string& command) {
 	auto mapIterator = factoryMap.find(command);
 	if (mapIterator != factoryMap.end()) {
 		std::unique_ptr<IExecutor> executor(mapIterator->second());
@@ -39,32 +53,46 @@ IExecutor* CompositExecutorFactory::createExecutor(const string& command) {
 }
 
 const unordered_map<string, ExecutorFactory::Creator> ExecutorFactory::factoryMap = {
-	{WRITE_CMD,              []() { return new OuputDecoratedWriter(); }},
-	{FULL_WRITE_CMD,         []() { return new FullWriter(); }},
-	{READ_CMD,               []() { return new OuputDecoratedReader(); }},
-	{FULL_READ_CMD,          []() { return new FullReader(); }},
-	{ERASE_CMD,              []() { return new Eraser(); }},
-	{ERASE_RANGE_CMD,        []() { return new RangeEraser(); }},
-	{HELP_CMD,               []() { return new Helper(); }},
-	{EXIT_CMD,               []() { return new Exiter(); }},
-	{FLUSH_CMD,              []() { return new Flusher(); }},
+	{WRITE_CMD,                []() { return new OuputDecoratedWriter(); }},
+	{FULL_WRITE_CMD,           []() { return new FullWriter(); }},
+	{READ_CMD,                 []() { return new OuputDecoratedReader(); }},
+	{FULL_READ_CMD,            []() { return new FullReader(); }},
+	{ERASE_CMD,                []() { return new Eraser(); }},
+	{ERASE_RANGE_CMD,          []() { return new RangeEraser(); }},
+	{HELP_CMD,                 []() { return new Helper(); }},
+	{EXIT_CMD,                 []() { return new Exiter(); }},
+	{FLUSH_CMD,                []() { return new Flusher(); }},
 
-	{FIRST_SCRIPT_SHORT_NAME, []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
-	{FIRST_SCRIPT_FULL_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{FIRST_SCRIPT_SHORT_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{FIRST_SCRIPT_FULL_NAME,   []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
 	{SECOND_SCRIPT_SHORT_NAME, []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
 	{SECOND_SCRIPT_FULL_NAME,  []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
-	{THIRD_SCRIPT_SHORT_NAME, []() { return new WriteReadAging(new Writer(), new Comparer()); }},
-	{THIRD_SCRIPT_FULL_NAME,  []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_SHORT_NAME,  []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_FULL_NAME,   []() { return new WriteReadAging(new Writer(), new Comparer()); }},
 	{FOURTH_SCRIPT_SHORT_NAME, []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 	{FOURTH_SCRIPT_FULL_NAME,  []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 };
 
 IExecutor* ExecutorFactory::createExecutor(const string& command) {
+	IExecutor* executor = getExecutorFromCache(command);
+	if (nullptr != executor) return executor;
+
+	executor = getExecutorFromMap(command);
+	if (nullptr != executor) return executor;
+
+	return nullptr;
+}
+
+IExecutor* ExecutorFactory::getExecutorFromCache(const string& command) {
 	auto cacheIterator = executorCache.find(command);
 	if (cacheIterator != executorCache.end()) {
 		return cacheIterator->second.get();
 	}
 
+	return nullptr;
+}
+
+IExecutor* ExecutorFactory::getExecutorFromMap(const string& command) {
 	auto mapIterator = factoryMap.find(command);
 	if (mapIterator != factoryMap.end()) {
 		std::unique_ptr<IExecutor> executor(mapIterator->second());

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -22,8 +22,20 @@ const unordered_map<string, CompositExecutorFactory::Creator> CompositExecutorFa
 };
 
 IExecutor* CompositExecutorFactory::createExecutor(const string& command) {
-	auto it = factoryMap.find(command);
-	return (it != factoryMap.end()) ? it->second() : nullptr;
+	auto it = executorCache.find(command);
+	if (it != executorCache.end()) {
+		return it->second.get();
+	}
+
+	auto factoryIt = factoryMap.find(command);
+	if (factoryIt != factoryMap.end()) {
+		std::unique_ptr<IExecutor> executor(factoryIt->second());
+		IExecutor* rawPtr = executor.get();
+		executorCache[command] = std::move(executor);
+		return rawPtr;
+	}
+
+	return nullptr;
 }
 
 const unordered_map<string, ExecutorFactory::Creator> ExecutorFactory::factoryMap = {
@@ -48,8 +60,20 @@ const unordered_map<string, ExecutorFactory::Creator> ExecutorFactory::factoryMa
 };
 
 IExecutor* ExecutorFactory::createExecutor(const string& command) {
-	auto it = factoryMap.find(command);
-	return (it != factoryMap.end()) ? it->second() : nullptr;
+	auto it = executorCache.find(command);
+	if (it != executorCache.end()) {
+		return it->second.get();
+	}
+
+	auto factoryIt = factoryMap.find(command);
+	if (factoryIt != factoryMap.end()) {
+		std::unique_ptr<IExecutor> executor(factoryIt->second());
+		IExecutor* rawPtr = executor.get();
+		executorCache[command] = std::move(executor);
+		return rawPtr;
+	}
+
+	return nullptr;
 }
 
 bool Writer::execute(ISsdApp* app, LBA lba, DATA data)

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -10,7 +10,7 @@
 
 using namespace std;
 
-const unordered_map<string, ScriptRunnerFactory::Creator> ScriptRunnerFactory::factoryMap = {
+const unordered_map<string, CompositExecutorFactory::Creator> CompositExecutorFactory::factoryMap = {
 	{FIRST_SCRIPT_SHORT_NAME, []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
 	{FIRST_SCRIPT_FULL_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
 	{SECOND_SCRIPT_SHORT_NAME, []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
@@ -21,7 +21,7 @@ const unordered_map<string, ScriptRunnerFactory::Creator> ScriptRunnerFactory::f
 	{FOURTH_SCRIPT_FULL_NAME,  []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 };
 
-IExecutor* ScriptRunnerFactory::createExecutor(const string& command) {
+IExecutor* CompositExecutorFactory::createExecutor(const string& command) {
 	auto it = factoryMap.find(command);
 	return (it != factoryMap.end()) ? it->second() : nullptr;
 }
@@ -36,11 +36,20 @@ const unordered_map<string, ExecutorFactory::Creator> ExecutorFactory::factoryMa
 	{HELP_CMD,               []() { return new Helper(); }},
 	{EXIT_CMD,               []() { return new Exiter(); }},
 	{FLUSH_CMD,              []() { return new Flusher(); }},
+
+	{FIRST_SCRIPT_SHORT_NAME, []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{FIRST_SCRIPT_FULL_NAME,  []() { return new FullWriteAndReadCompare(new Writer(), new Comparer()); }},
+	{SECOND_SCRIPT_SHORT_NAME, []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
+	{SECOND_SCRIPT_FULL_NAME,  []() { return new PartialLBAWrite(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_SHORT_NAME, []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{THIRD_SCRIPT_FULL_NAME,  []() { return new WriteReadAging(new Writer(), new Comparer()); }},
+	{FOURTH_SCRIPT_SHORT_NAME, []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
+	{FOURTH_SCRIPT_FULL_NAME,  []() { return new EraseAndWriteAging(new Writer(), new Comparer(), new Eraser()); }},
 };
 
 IExecutor* ExecutorFactory::createExecutor(const string& command) {
 	auto it = factoryMap.find(command);
-	return (it != factoryMap.end()) ? it->second() : ScriptRunnerFactory::createExecutor(command);
+	return (it != factoryMap.end()) ? it->second() : nullptr;
 }
 
 bool Writer::execute(ISsdApp* app, LBA lba, DATA data)

--- a/TestShell/executor.cpp
+++ b/TestShell/executor.cpp
@@ -22,14 +22,14 @@ const unordered_map<string, CompositExecutorFactory::Creator> CompositExecutorFa
 };
 
 IExecutor* CompositExecutorFactory::createExecutor(const string& command) {
-	auto it = executorCache.find(command);
-	if (it != executorCache.end()) {
-		return it->second.get();
+	auto cacheIterator = executorCache.find(command);
+	if (cacheIterator != executorCache.end()) {
+		return cacheIterator->second.get();
 	}
 
-	auto factoryIt = factoryMap.find(command);
-	if (factoryIt != factoryMap.end()) {
-		std::unique_ptr<IExecutor> executor(factoryIt->second());
+	auto mapIterator = factoryMap.find(command);
+	if (mapIterator != factoryMap.end()) {
+		std::unique_ptr<IExecutor> executor(mapIterator->second());
 		IExecutor* rawPtr = executor.get();
 		executorCache[command] = std::move(executor);
 		return rawPtr;
@@ -60,14 +60,14 @@ const unordered_map<string, ExecutorFactory::Creator> ExecutorFactory::factoryMa
 };
 
 IExecutor* ExecutorFactory::createExecutor(const string& command) {
-	auto it = executorCache.find(command);
-	if (it != executorCache.end()) {
-		return it->second.get();
+	auto cacheIterator = executorCache.find(command);
+	if (cacheIterator != executorCache.end()) {
+		return cacheIterator->second.get();
 	}
 
-	auto factoryIt = factoryMap.find(command);
-	if (factoryIt != factoryMap.end()) {
-		std::unique_ptr<IExecutor> executor(factoryIt->second());
+	auto mapIterator = factoryMap.find(command);
+	if (mapIterator != factoryMap.end()) {
+		std::unique_ptr<IExecutor> executor(mapIterator->second());
 		IExecutor* rawPtr = executor.get();
 		executorCache[command] = std::move(executor);
 		return rawPtr;
@@ -206,7 +206,7 @@ bool Comparer::Compare(const DATA expectedData, const string &readResult)
 	if (expectedData == readData) return true;
 
 	SHELL_LOG("[Compare] Fail Expected ", expectedData);
-	SHELL_LOG("[Caompre] Fail Real ", readData);
+	SHELL_LOG("[Compare] Fail Real ", readData);
 
 	return false;
 }

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -34,6 +35,7 @@ public:
 	virtual IExecutor* createExecutor(const string& command) = 0;
 protected:
 	using Creator = std::function<IExecutor* ()>;
+	unordered_map<string, std::unique_ptr<IExecutor>> executorCache;
 };
 
 class CompositExecutorFactory : public IExecutorFactory {
@@ -49,4 +51,5 @@ public:
 private:
 	static const unordered_map<string, Creator> factoryMap;
 };
+
 

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -29,20 +29,24 @@ interface ICommandParserBridge {
 	virtual bool ExecuteSsdUsingParsedCommand(ISsdApp* app) = 0;
 };
 
-class ScriptRunnerFactory {
+class IExecutorFactory {
 public:
-	virtual IExecutor* createExecutor(const string& command);
-private:
+	virtual IExecutor* createExecutor(const string& command) = 0;
+protected:
 	using Creator = std::function<IExecutor* ()>;
-	static const unordered_map<string, Creator> factoryMap;
 };
 
-
-class ExecutorFactory : public ScriptRunnerFactory {
+class CompositExecutorFactory : public IExecutorFactory {
 public:
 	IExecutor* createExecutor(const string& command) override;
 private:
-	using Creator = std::function<IExecutor* ()>;
+	static const unordered_map<string, Creator> factoryMap;
+};
+
+class ExecutorFactory : public IExecutorFactory {
+public:
+	IExecutor* createExecutor(const string& command);
+private:
 	static const unordered_map<string, Creator> factoryMap;
 };
 

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <functional>
 
 using std::string;
 using std::vector;
+using std::unordered_map;
 
 #define interface struct
 
@@ -16,19 +19,30 @@ interface ISsdApp {
 	virtual bool Flush() = 0;
 };
 
-interface IExecutor{
+interface IExecutor {
 	virtual bool IsValidCommand(const vector<string>& tokens) { return false; }
 	virtual bool execute(ISsdApp* pApp = nullptr, u32 lba = 0, u32 data = 0) = 0;
 };
 
-class ICommandParserBridge
-{
-public:
+interface ICommandParserBridge {
 	virtual bool ParseCommand(const string& cmd) = 0;
 	virtual bool ExecuteSsdUsingParsedCommand(ISsdApp* app) = 0;
 };
 
-class ExecutorFactory {
+class ScriptRunnerFactory {
 public:
-	IExecutor* createExecutor(const string command);
+	virtual IExecutor* createExecutor(const string& command);
+private:
+	using Creator = std::function<IExecutor* ()>;
+	static const unordered_map<string, Creator> factoryMap;
 };
+
+
+class ExecutorFactory : public ScriptRunnerFactory {
+public:
+	IExecutor* createExecutor(const string& command) override;
+private:
+	using Creator = std::function<IExecutor* ()>;
+	static const unordered_map<string, Creator> factoryMap;
+};
+

--- a/TestShell/interface.h
+++ b/TestShell/interface.h
@@ -36,11 +36,17 @@ public:
 protected:
 	using Creator = std::function<IExecutor* ()>;
 	unordered_map<string, std::unique_ptr<IExecutor>> executorCache;
+
+	virtual IExecutor* getExecutorFromCache(const string& command);
+	virtual IExecutor* getExecutorFromMap(const string& command);
 };
 
 class CompositExecutorFactory : public IExecutorFactory {
 public:
 	IExecutor* createExecutor(const string& command) override;
+protected:
+	IExecutor* getExecutorFromCache(const string& command) override;
+	IExecutor* getExecutorFromMap(const string& command) override;
 private:
 	static const unordered_map<string, Creator> factoryMap;
 };
@@ -48,6 +54,9 @@ private:
 class ExecutorFactory : public IExecutorFactory {
 public:
 	IExecutor* createExecutor(const string& command);
+protected:
+	IExecutor* getExecutorFromCache(const string& command) override;
+	IExecutor* getExecutorFromMap(const string& command) override;
 private:
 	static const unordered_map<string, Creator> factoryMap;
 };

--- a/TestShell/runner.cpp
+++ b/TestShell/runner.cpp
@@ -7,8 +7,6 @@
 
 using namespace std;
 
-#define _RUNNER
-
 int Shell::Runner(int argc, char* argv[])
 {
     if (argc != 2)

--- a/TestShell/runner.cpp
+++ b/TestShell/runner.cpp
@@ -7,6 +7,8 @@
 
 using namespace std;
 
+#define _RUNNER
+
 int Shell::Runner(int argc, char* argv[])
 {
     if (argc != 2)
@@ -24,20 +26,19 @@ int Shell::Runner(int argc, char* argv[])
     }
 
     if (commandParser == nullptr)
-        commandParser = new CommandParser();
+        commandParser = new CommandParser(new CompositExecutorFactory());
 
     string cmd;
     while (std::getline(infile, cmd)) {
         if (cmd.empty())
         {
-            print("[Runner] Empty Line");
             return 0; // Empty Line
         }
 
         printWithoutLineBreak(cmd + "  ___  ");
         if (!commandParser->ParseCommand(cmd))
         {
-            print("[Runner] Invalid Command");
+            print("FAIL!");
             return 0; // Invalid command
         }
 

--- a/TestShell/runner.cpp
+++ b/TestShell/runner.cpp
@@ -34,12 +34,14 @@ int Shell::Runner(int argc, char* argv[])
             return 0; // Empty Line
         }
 
+        printWithoutLineBreak(cmd + "  ___  ");
         if (!commandParser->ParseCommand(cmd))
         {
             print("[Runner] Invalid Command");
             return 0; // Invalid command
         }
 
+        printWithoutLineBreak("Run()...");
         commandParser->ExecuteSsdUsingParsedCommand(SsdApp::getInstance());
     }
 

--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -9,7 +9,7 @@ int Shell::RunShellLoop(void) {
     string cmd;
 
     if (commandParser == nullptr)
-        commandParser = new CommandParser();
+        commandParser = new CommandParser(new ExecutorFactory());
 
     do {
         cout << "Shell> ";

--- a/TestShell/utils.cpp
+++ b/TestShell/utils.cpp
@@ -84,6 +84,10 @@ void print(const string& desc) {
 	cout << desc << endl;
 }
 
+void printWithoutLineBreak(const string& desc) {
+	cout << desc;
+}
+
 void dbgPring(const string& desc) {
 #ifdef _DEBUG
 	cout << desc << endl;

--- a/TestShell/utils.h
+++ b/TestShell/utils.h
@@ -14,4 +14,5 @@ public:
 };
 
 void print(const string& desc);
+void printWithoutLineBreak(const string& desc);
 void dbgPring(const string& desc);


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #208

## 제목
- [#208][Refactor] refactor ExecutorFactory and add Shell Log to Runner

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- Shell과 Runner용 Executor set을 반환하는 Factory를 각각 생성
- 위 Factory의 private멤버변수로 cmd와 생성자를 요소로 갖는 static map 멤버변수를 추가하여 2번째 호출 시에는 만들어진 오브젝트를 바로 반환할 수 있게 함
- Runner script로 돌릴 때 요구사항에 맞게 shell에 logging하도록 수정