### PR TITLE
[#216][REFACTOR] Fix warnning message logFile.tellp()

### DIFF
--- a/TestShell/logger.cpp
+++ b/TestShell/logger.cpp
@@ -169,7 +169,7 @@ bool LatestLogState::CheckChangeUntil(ofstream& logfile) {
     return false;
 }
 
-int LatestLogState::GetLatestLogSize(ofstream& logFile) {
+size_t LatestLogState::GetLatestLogSize(ofstream& logFile) {
     return logFile.tellp();
 }
 

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -83,7 +83,7 @@ private:
     void WriteMessageToFile(ofstream& logfile, const std::string& message);
     bool CheckChangeUntil(ofstream& logfile);
 
-    int GetLatestLogSize(ofstream& logFile);
+    size_t GetLatestLogSize(ofstream& logFile);
 };
 
 class Logger {


### PR DESCRIPTION
# Pull Request Template

## 이슈 번호
- #216

## 제목
- [REFACTOR] Fix warnning message logFile.tellp()

## 프로젝트
- [ ] SSD
- [x] TestShell
- [ ] TestScript

## 변경 사항
- 아래 warnning message 해결.
- return': 'std::streamoff'에서 'int'(으)로 변환하면서 데이터가 손실될 수 있습니다. TestShell C:\work\CCC-SSDProject\TestShell\logger.cpp 173
