### PR TITLE
[#236][UnitTest] Buffer 개수 확인하는 UT 작성

### DIFF
--- a/SSDProject/BufferedSSD.cpp
+++ b/SSDProject/BufferedSSD.cpp
@@ -13,7 +13,7 @@ BufferedSSD::BufferedSSD() {
 	if (_access(BUFFER_DIRECTORY.c_str(), 0) != 0)
 	{
 		int ret = _mkdir(BUFFER_DIRECTORY.c_str());
-		DEBUG_ASSERT(ret, "CANNOT MAKE BUFFER DIRECTORY");
+		DEBUG_ASSERT(ret != -1, "CANNOT MAKE BUFFER DIRECTORY");
 		_DumpCommand();
 	}
 }

--- a/SSDProject/BufferedSSD.h
+++ b/SSDProject/BufferedSSD.h
@@ -23,6 +23,9 @@ public:
 	bool Write(LBA lba, DATA data) override;
 	bool Erase(LBA lba, unsigned int size) override;
 	void Flush() override;
+#ifdef _DEBUG
+	int GetCmdCnt() { return _GetCmdCnt(); }
+#endif
 
 private:
 	bool _NeedFlush();

--- a/SSDProject/SSDProject.vcxproj
+++ b/SSDProject/SSDProject.vcxproj
@@ -153,6 +153,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="BufferedSSD.cpp" />
+    <ClCompile Include="buffer_test.cpp" />
     <ClCompile Include="hostInterface.cpp" />
     <ClCompile Include="hostInterface_test.cpp" />
     <ClCompile Include="main.cpp" />

--- a/SSDProject/SSDProject.vcxproj.filters
+++ b/SSDProject/SSDProject.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="ssd.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="buffer_test.cpp">
+      <Filter>테스트 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="nand.h">

--- a/SSDProject/buffer_test.cpp
+++ b/SSDProject/buffer_test.cpp
@@ -1,0 +1,141 @@
+#ifdef _DEBUG
+#include "gmock/gmock.h"
+#include "hostInterface.h"
+#include <string>
+#include <vector>
+#include <array>
+#include <utility>
+
+class BufferFixture : public testing::Test {
+protected:
+    void SetUp()
+    {
+        char** argv = const_cast<char**>(FLUSH_ARGV.data());
+        HostInterface::GetInstance()->Execute(FLUSH_ARGC, argv);
+        
+    }
+    BufferedSSD *ssd;
+    const std::array<char*, 2> FLUSH_ARGV = { (char*)"SSD.exe", (char*)"F" };
+    const int FLUSH_ARGC = 2;
+    const int WRITE_ARGC = 4;
+    const int ERASE_ARGC = 4;
+    const int READ_ARGC = 3;
+
+    void HostExecute(char** argv)
+    {
+        HostInterface* host = HostInterface::GetInstance();
+        ssd = new BufferedSSD();
+        host->SetSSD(ssd);
+        if (argv[1] == "W") host->Execute(WRITE_ARGC, argv);
+        if (argv[1] == "E") host->Execute(ERASE_ARGC, argv);
+        if (argv[1] == "R") host->Execute(READ_ARGC, argv);
+        if (argv[1] == "F") host->Execute(FLUSH_ARGC, argv);
+    }
+
+    const std::vector<std::pair<std::array<char*, 4>, int>> BUFFER_WRITE_ONLY_TEST_ARGV_LIST = {
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"13", (char*)"0x12345678" }, 1},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"14", (char*)"0x12345678" }, 2}, 
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"13", (char*)"0x12345678" }, 2}, // overwrite case
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"14", (char*)"0x12345678" }, 2}, // overwrite case
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"15", (char*)"0x12345678" }, 3},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"16", (char*)"0x12345678" }, 4},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"17", (char*)"0x12345678" }, 5},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"13", (char*)"0x12345678" }, 1}, // flush first
+    };
+
+    const std::vector<std::pair<std::array<char*, 4>, int>> BUFFER_ERASE_ONLY_TEST_ARGV_LIST = {
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"0",  (char*)"10" },  1},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"10", (char*)"10" },  2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"0",  (char*)"10" },  2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"20", (char*)"10" },  3},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"50", (char*)"2"  },  4}, 
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"52", (char*)"1"  },  4}, 
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"53", (char*)"3"  },  4},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"56", (char*)"4"  },  4},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"60", (char*)"1"  },  5},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"61", (char*)"1"  },  1}, // flush first
+    };
+
+    const std::vector<std::pair<std::array<char*, 4>, int>> BUFFER_TEST_EXAMPLE_IGNORE_COMMAND = {
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"20", (char*)"0xABCDABCD" }, 1},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"21", (char*)"0x12341234" }, 2},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"20", (char*)"0xEEEEFFFF" }, 2}, 
+        {{ (char*)"SSD.exe", (char*)"F", (char*)"  ", (char*)"          " }, 0}, 
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"18", (char*)         "3" }, 1},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"21", (char*)"0x12341234" }, 2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"18", (char*)         "5" }, 1},
+    };
+
+    const std::vector<std::pair<std::array<char*, 4>, int>> BUFFER_TEST_EXAMPLE_MERGE_ERASE = {
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"20", (char*)"0xABCDABCD" }, 1},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"10", (char*)         "4" }, 2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"12", (char*)         "3" }, 2},
+    };
+
+    const std::vector<std::pair<std::array<char*, 4>, int>> BUFFER_TEST_MIXED_WRITE_ERASE_1 = {
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"0",  (char*)        "10" }, 1},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"10", (char*)"0xABCDABCD" }, 2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"11", (char*)        "10" }, 3},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"21", (char*)         "3" }, 4},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"24", (char*)        "10" }, 5},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"13", (char*)"0xABCDABCD" }, 1},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"10", (char*)         "3" }, 2},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"14", (char*)         "6" }, 2},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"14", (char*)"0xABCDABCD" }, 3},
+        {{ (char*)"SSD.exe", (char*)"W", (char*)"15", (char*)"0xABCDABCD" }, 4},
+        {{ (char*)"SSD.exe", (char*)"E", (char*)"13", (char*)         "3" }, 1},
+    };
+
+};
+
+TEST_F(BufferFixture, WRITE_ONLY_BUFFER_TEST)
+{
+    for (auto test_case : BUFFER_WRITE_ONLY_TEST_ARGV_LIST)
+    {
+        char** argv = const_cast<char**>(test_case.first.data());
+        HostExecute(argv);
+        EXPECT_EQ(ssd->GetCmdCnt(), test_case.second);
+    }
+}
+
+TEST_F(BufferFixture, ERASE_ONLY_BUFFER_TEST)
+{
+    for (auto test_case : BUFFER_ERASE_ONLY_TEST_ARGV_LIST)
+    {
+        char** argv = const_cast<char**>(test_case.first.data());
+        HostExecute(argv);
+        EXPECT_EQ(ssd->GetCmdCnt(), test_case.second);
+    }
+}
+
+TEST_F(BufferFixture, IGNORE_COMNMAND_BUFFER_TEST)
+{
+    for (auto test_case : BUFFER_TEST_EXAMPLE_IGNORE_COMMAND)
+    {
+        char** argv = const_cast<char**>(test_case.first.data());
+        HostExecute(argv);
+        EXPECT_EQ(ssd->GetCmdCnt(), test_case.second);
+    }
+}
+
+TEST_F(BufferFixture, MERGE_ERASE_BUFFER_TEST)
+{
+    for (auto test_case : BUFFER_TEST_EXAMPLE_MERGE_ERASE)
+    {
+        char** argv = const_cast<char**>(test_case.first.data());
+        HostExecute(argv);
+        EXPECT_EQ(ssd->GetCmdCnt(), test_case.second);
+    }
+}
+
+TEST_F(BufferFixture, MIXED_BUFFER_TEST_1)
+{
+    for (auto test_case : BUFFER_TEST_MIXED_WRITE_ERASE_1)
+    {
+        char** argv = const_cast<char**>(test_case.first.data());
+        HostExecute(argv);
+        EXPECT_EQ(ssd->GetCmdCnt(), test_case.second);
+    }
+}
+
+#endif


### PR DESCRIPTION
추가적으로 Buffer 개수를 확인하기 위한 API를 BufferedSSD.h에 추가합니다.

# Pull Request Template

## 이슈 번호
- 이 PR이 해결하는 이슈 번호를 적어주세요. 예: `#123` #236 

## 제목
- [PREFIX] PR 제목을 간결하게 작성해주세요. [#236][UnitTest] Buffer 개수 확인하는 UT 작성

## 프로젝트
- [x] SSD
- [ ] TestShell
- [ ] TestScript

## 변경 사항
- Buffer 개수를 확인할 수 있는 UT를 작성합니다. 
- Pair 자료구조를 통해 문제 / 정답을 같이 묶어두어서 문제에 대한 의도된 정답이 나오는지 쉽게 제작할 수 있도록 만들었습니다.
- Buffer Test 이전에 항상 Flush 동작을 수행하여, TC를 돌릴 때 마다 의도된 결과가 나오도록 제작하였습니다.
- 현재 Debug / Release에서의 환경 차이로 인해 발생하는 버그가 존재합니다. 해당 버그는 DEBUG 옵션에서만 발생하는 버그이기 때문에, 해당 UT 제작 Issue에 같이 넣으려고 합니다.